### PR TITLE
Add ErlangCheck

### DIFF
--- a/ErlangCheck.py
+++ b/ErlangCheck.py
@@ -15,10 +15,7 @@ import commands
 import Config
 import stat
 
-try:
-	from pybeam import BeamFile
-except:
-	BeamFile = None
+from pybeam import BeamFile
 
 class ErlangCheck(AbstractCheck.AbstractFilesCheck):
     def __init__(self):
@@ -33,22 +30,10 @@ class ErlangCheck(AbstractCheck.AbstractFilesCheck):
         if not self.source_re.match(beam.compileinfo['source'].value):
             printWarning(pkg, "beam-was-not-recompiled", filename, beam.compileinfo['source'].value)
 
-class DummyErlangCheck(AbstractCheck.AbstractFilesCheck):
-    def __init__(self):
-        AbstractCheck.AbstractFilesCheck.__init__(self, "ErlangCheck", ".*?\.beam$")
-
-    def check_file(self, pkg, filename):
-        printWarning(pkg, "beam-found-but-no-pybeam-installed", filename)
-
-if BeamFile:
-	check=ErlangCheck()
-else:
-	check=DummyErlangCheck()
+check=ErlangCheck()
 
 if Config.info:
     addDetails(
-'beam-found-but-no-pybeam-installed',
-"It would be possible to do some erlang-specific diagnostic, If python-pybeam were installed.",
 'beam-compiled-without-debug_info',
 "Your beam file indicates that it doesn't contain debug_info. Please, make sure that you compile with +debug_info.",
 'beam-was-not-recompiled',


### PR DESCRIPTION
Hi,

This is a copy of pull-request to upstream rpmlint[1], which is neither rejected nor accepted for month. However, some maintainer's demands have been taken into account.

This consists of two fully production-useful checks:
- beam-compiled-without-debug_info
- beam-was-not-recompiled
  They had been tested month ago at OBS before the request to upstream was created.

However, to fully enable this checks, one need to put python-pybeam into rpmlint-mini. There is another extra dummy check to keep rpmlint working when python pybeam package is not installed. It prevents rpmlint from crash and prints 'beam-found-but-no-pybeam-installed'.

[1] http://sourceforge.net/p/rpmlint/code/merge-requests/2/
[2] http://lists.opensuse.org/opensuse-packaging/2013-05/msg00064.html
