### PR TITLE
Added checks for proper handling of systemd unit files

### DIFF
--- a/CheckSystemdInstall.py
+++ b/CheckSystemdInstall.py
@@ -15,10 +15,9 @@ from Filter import addDetails, printWarning
 
 # check only for files copied to this directory
 SYSTEMD_SERVICE_DIRECTORY = "/usr/lib/systemd/system"
-
 # we could extend this later on
-CHECKED_UNITS = [ 'service', 'socket' ]
-CHECKED_UNITS_REGEXP = re.compile( "(" + '|'.join(CHECKED_UNITS) + ")$"  )
+CHECKED_UNITS = [ 'service', 'socket', 'target' ]
+CHECKED_UNITS_REGEXP = re.compile( SYSTEMD_SERVICE_DIRECTORY + ".+\.(" + '|'.join(CHECKED_UNITS) + ")$"  )
 
 class CheckSystemdInstall(AbstractCheck.AbstractCheck):
 
@@ -38,7 +37,7 @@ class CheckSystemdInstall(AbstractCheck.AbstractCheck):
 
         for fname, pkgfile in pkg.files().items():
 
-            if fname.startswith( SYSTEMD_SERVICE_DIRECTORY ) and CHECKED_UNITS_REGEXP.search( fname ):
+            if CHECKED_UNITS_REGEXP.search( fname ):
                 processed = { 'pre': False, 'post': False, 'preun': False, 'postun': False }
 
                 escaped_basename = re.escape( os.path.basename( fname ) )

--- a/tests/CheckFilelists/systemd-bad.spec
+++ b/tests/CheckFilelists/systemd-bad.spec
@@ -1,0 +1,21 @@
+Name:		systemd-bad
+Version:	0
+Release:	0
+Group:          Development/Tools/Building
+Summary:	Bar
+License:	GPL
+BuildRoot:	%_tmppath/%name-%version-build
+
+%description
+%_target
+%_target_cpu
+
+%install
+install -D -m 644 /dev/null %buildroot/usr/lib/systemd/system/mysql.service
+
+%clean
+rm -rf %buildroot
+
+%files
+%defattr(-,root,root)
+/usr/lib/systemd/system/mysql.service

--- a/tests/CheckFilelists/systemd-good.spec
+++ b/tests/CheckFilelists/systemd-good.spec
@@ -1,0 +1,33 @@
+Name:		systemd-bad
+Version:	0
+Release:	0
+Group:          Development/Tools/Building
+Summary:	Bar
+License:	GPL
+BuildRoot:	%_tmppath/%name-%version-build
+
+%description
+%_target
+%_target_cpu
+
+%install
+install -D -m 644 /dev/null %buildroot/usr/lib/systemd/system/mysql.service
+
+%pre
+%service_add_pre mysql.service
+
+%preun
+%service_del_preun mysql.service
+
+%post
+%service_add_post mysql.service
+
+%postun
+%service_del_postun mysql.service
+
+%clean
+rm -rf %buildroot
+
+%files
+%defattr(-,root,root)
+/usr/lib/systemd/system/mysql.service


### PR DESCRIPTION
This checks for proper handling of systemd unit files. For every .socket/.service file that is copied to /usr/lib/systemd/system it is checked that
- %pre contains %service_add_pre 
- %post contains %service_add_post
- %preun contains %service_del_preun
- %postun contains %service_del_postun
  for this file
