### PR TITLE
Make checks python3 compatible

### DIFF
--- a/BashismsCheck.py
+++ b/BashismsCheck.py
@@ -34,6 +34,8 @@ class BashismsCheck(AbstractCheck.AbstractFilesCheck):
                         printInfo(pkg, "potential-bashisms", filename)
                 except Exception as x:
                     printError(pkg, 'rpmlint-exception', "%(file)s raised an exception: %(x)s" % {'file':filename, 'x':x})
+        except UnicodeDecodeError:
+            pass
         finally:
             f.close()
 

--- a/BrandingPolicyCheck.py
+++ b/BrandingPolicyCheck.py
@@ -22,7 +22,7 @@ class BrandingPolicyCheck(AbstractCheck.AbstractCheck):
         if pkg.isSource():
             return
 
-        pkg_requires = set(map(lambda x: string.split(x[0], '(')[0], pkg.requires()))
+        pkg_requires = set(map(lambda x: str.split(x[0], '(')[0], pkg.requires()))
         pkg_conflicts = set(map(lambda x: x[0], pkg.conflicts()))
 
         # verify that only generic branding is required by non-branding packages
@@ -52,7 +52,7 @@ class BrandingPolicyCheck(AbstractCheck.AbstractCheck):
         branding_style = pkg.name.partition('-branding-')[2]
         generic_branding = ("%s-branding" % (branding_basename))
 
-        pkg_provides = set(map(lambda x: string.split(x[0], '(')[0], pkg.provides()))
+        pkg_provides = set(map(lambda x: str.split(x[0], '(')[0], pkg.provides()))
         pkg_supplements = set(map(lambda x: x[0], pkg.supplements()))
 
         # verify that it only supplements with packageand

--- a/CheckFilelist.py
+++ b/CheckFilelist.py
@@ -397,7 +397,7 @@ class FilelistCheck(AbstractCheck.AbstractCheck):
         invalidopt = set()
 
         isSUSE = (pkg.header[RPMTAG_VENDOR] and
-                  'SUSE' in pkg.header[RPMTAG_VENDOR])
+                  b'SUSE' in pkg.header[RPMTAG_VENDOR])
 
         # the checks here only warn about a directory once rather
         # than reporting potentially hundreds of files individually

--- a/CheckInitScripts.py
+++ b/CheckInitScripts.py
@@ -25,8 +25,8 @@ class CheckInitScripts(AbstractCheck.AbstractFilesCheck):
             return
 
         files = pkg.files()
-        bins_list = filter(lambda f: (f.startswith("/usr/bin") \
-                or f.startswith("/usr/sbin")) and stat.S_ISREG(files[f].mode), files.keys())
+        bins_list = (f for f in files.keys() if (f.startswith("/usr/bin") \
+                or f.startswith("/usr/sbin")) and stat.S_ISREG(files[f].mode))
 
         for f, pkgfile in files.items():
 
@@ -35,7 +35,7 @@ class CheckInitScripts(AbstractCheck.AbstractFilesCheck):
 
             boot_script = f.startswith('/etc/init.d/boot.')
 
-            input_f = file(pkg.dirName() + '/' + f, "r")
+            input_f = open(pkg.dirName() + '/' + f, "r")
             found_remote_fs = False
             for l in input_f:
                 if l.startswith('# Required-Start') or l.startswith('# Should-Start'):
@@ -65,7 +65,7 @@ class CheckInitScripts(AbstractCheck.AbstractFilesCheck):
                         if dep == '4':
                             printError(pkg, "init-script-runlevel-4", f)
 
-            if not found_remote_fs and bins_list:
+            if not found_remote_fs and any(bins_list):
                 printWarning(pkg, "non-remote_fs-dependency", f)
 
 

--- a/CheckKDE4Deps.py
+++ b/CheckKDE4Deps.py
@@ -61,7 +61,7 @@ class KDE4Check(AbstractCheck.AbstractCheck):
         if pkg.isSource():
             return
 
-        pkg_requires = set(map(lambda x: string.split(x[0],'(')[0], pkg.requires()))
+        pkg_requires = set(map(lambda x: str.split(x[0],'(')[0], pkg.requires()))
 
         if not "libkdecore.so.5" in pkg_requires:
             return

--- a/CheckPkgConfig.py
+++ b/CheckPkgConfig.py
@@ -37,7 +37,7 @@ class PkgConfigCheck(AbstractCheck.AbstractFilesCheck):
         if pkg.grep(self.suspicious_dir, filename):
             Filter.printError(pkg, "invalid-pkgconfig-file", filename)
 
-        pc_file = file(pkg.dirName() + "/" + filename, "r")
+        pc_file = open(pkg.dirName() + "/" + filename, "r")
         for l in pc_file:
             if l.startswith('Libs:') and self.wronglib_dir.search(l):
                 Filter.printError(pkg, 'pkgconfig-invalid-libs-dir',

--- a/CheckUpdateAlternatives.py
+++ b/CheckUpdateAlternatives.py
@@ -31,7 +31,7 @@ class CheckUpdateAlternatives(AbstractCheck.AbstractCheck):
     @classmethod
     def read_ghost_files(cls, script):
 
-        if not script or not 'update-alternatives' in script:
+        if not script or not b'update-alternatives' in script:
             return set()
 
         ghost_files = set()

--- a/DuplicatesCheck.py
+++ b/DuplicatesCheck.py
@@ -15,7 +15,7 @@ import string
 
 
 def get_prefix(file):
-    pathlist = string.split(file, '/')
+    pathlist = str.split(file, '/')
     if len(pathlist) == 3:
         return "/".join(pathlist[0:2])
 

--- a/LibraryPolicyCheck.py
+++ b/LibraryPolicyCheck.py
@@ -284,7 +284,7 @@ from BinariesCheck import BinaryInfo
 
 
 def libname_from_soname(soname):
-    libname = string.split(soname, '.so.')
+    libname = str.split(soname, '.so.')
     if len(libname) == 2:
         if libname[0][-1:].isdigit():
             libname = string.join(libname, '-')
@@ -319,7 +319,7 @@ class LibraryPolicyCheck(AbstractCheck.AbstractCheck):
         libs_to_dir = dict()
         dirs = set()
         reqlibs = set()
-        pkg_requires = set(map(lambda x: string.split(x[0], '(')[0],
+        pkg_requires = set(map(lambda x: str.split(x[0], '(')[0],
                                pkg.requires()))
 
         for f, pkgfile in files.items():
@@ -432,7 +432,7 @@ class LibraryPolicyCheck(AbstractCheck.AbstractCheck):
             done = set()
             for dir in dirs:
                 if dir.startswith(sysdir + '/'):
-                    ssdir = string.split(dir[len(sysdir)+1:], '/')[0]
+                    ssdir = str.split(dir[len(sysdir)+1:], '/')[0]
                     if not ssdir[-1].isdigit():
                         cdirs.add(sysdir+'/'+ssdir)
                     done.add(dir)


### PR DESCRIPTION
- string module no longer has a split method, use str.split()
- binary files contain no bashisms, ignore any UnicodeDecodeErrors
- file objects should be created with open
- RPMTAGs may be bytes objects, match has to be bytes as well
- filter returns an filter object, which is always true, use list
  comprehension, which is preferred in modern python

Python2 is not affected by the changes, rpmlint-tests-master pass