### PR TITLE
Fix update-alternatives check when it's quoted

### DIFF
--- a/CheckUpdateAlternatives.py
+++ b/CheckUpdateAlternatives.py
@@ -38,6 +38,7 @@ class CheckUpdateAlternatives(AbstractCheck.AbstractCheck):
 
         for command in (
                 c.replace('\\\n', '').strip()
+                c.replace('\\\n', '').replace('"','').strip()
                 for c in script.split('update-alternatives')
                 if cls.INSTALL in c):
 


### PR DESCRIPTION
Quotes (") around the update-alternatives command cause a bug when
parsing. This fixes it.

See:
https://bugzilla.suse.com/show_bug.cgi?id=994259 and its tracker bug
https://bugzilla.suse.com/show_bug.cgi?id=994084 .

Cheers.