### PR TITLE
Support uppercase tag macros used by RPM 4.14

### DIFF
--- a/CheckBuildRoot.py
+++ b/CheckBuildRoot.py
@@ -18,7 +18,7 @@ class BuildRootCheck(AbstractCheck.AbstractFilesCheck):
     def __init__(self):
         AbstractCheck.AbstractFilesCheck.__init__(self, "CheckBuildRoot", ".*")
         t = rpm.expandMacro('%buildroot')
-        for m in ('name', 'version', 'release'):
+        for m in ('name', 'version', 'release', 'NAME', 'VERSION', 'RELEASE'):
             t = t.replace("%%{%s}" % (m), r'[\w\!-\.]{1,20}')
         self.build_root_re = re.compile(t)
 


### PR DESCRIPTION
RPM 4.14 stores main package tags (e.g. %{VERSION}) in uppercase. These
are e.g. used in the %{buildroot} macro. Replace both lowercase and
uppercase variants for compatibility with old and new versions.