### PR TITLE
polkit: make untracked privileges also an error

### DIFF
--- a/CheckPolkitPrivs.py
+++ b/CheckPolkitPrivs.py
@@ -122,7 +122,7 @@ class PolkitCheck(AbstractCheck.AbstractCheck):
                                         settings['allow_inactive'],
                                         settings['allow_active']))
                             else:
-                                printInfo(
+                                printError(
                                     pkg, 'polkit-untracked-privilege',
                                     '%s (%s:%s:%s)' % (
                                         action,


### PR DESCRIPTION
Even if all fields are set to "auth_admin" there is still a security
risk involved. Application can implement polkit checks not at all or
badly. The mere presence of the "auth_admin" config does not mean it is
safe.