### PR TITLE
Blacklist python test folder in python packages

### DIFF
--- a/CheckFilelist.py
+++ b/CheckFilelist.py
@@ -137,6 +137,14 @@ _checks = [
         ],
     },
     {
+        'error': 'suse-filelist-forbidden-python-test-dir',
+        'details': '''python package installs testsuite to the sitelib,
+                        which can cause file list conflict and is not allowed in SUSE.''',
+        'bad': [
+            '/usr/lib*/python*/site-packages/test',
+        ],
+    },
+    {
         'error': 'suse-filelist-forbidden-backup-file',
         'details': 'backup files (~, .swp or .bak) are not allowed',
         'bad': [


### PR DESCRIPTION
This should later on avoid us on:

found conflict of python-hp3parclient-3.3.2-1.1.noarch with python2-txtorcon-0.20.0-3.1.noarch:   - /usr/lib/python2.7/site-packages/test/__init__.py   - /usr/lib/python2.7/site-packages/test/__init__.pyc