### PR TITLE
Add path units and exclude @ units issue #31

### DIFF
--- a/CheckSystemdInstall.py
+++ b/CheckSystemdInstall.py
@@ -15,8 +15,8 @@ from Filter import addDetails, printWarning
 # check only for files copied to this directory
 SYSTEMD_SERVICE_DIRECTORY = "/usr/lib/systemd/system"
 # we could extend this later on
-CHECKED_UNITS = ['service', 'socket', 'target']
-CHECKED_UNITS_REGEXP = re.compile("^" + SYSTEMD_SERVICE_DIRECTORY + r'.+\.(' + '|'.join(CHECKED_UNITS) + ')$')
+CHECKED_UNITS = ['service', 'socket', 'target', 'path']
+CHECKED_UNITS_REGEXP = re.compile("^" + SYSTEMD_SERVICE_DIRECTORY + r'.+[^@]\.(' + '|'.join(CHECKED_UNITS) + ')$')
 
 
 class CheckSystemdInstall(AbstractCheck.AbstractCheck):


### PR DESCRIPTION
This fixes problem where rpmlint tells user to use pre/post/...
scriptlets on files where it is actually harmfull to run.