### PR TITLE
There isn't a good standard, whether the directory should be called 'tests/' or 'test/'

### DIFF
--- a/CheckFilelist.py
+++ b/CheckFilelist.py
@@ -142,6 +142,7 @@ _checks = [
                         which can cause file list conflict and is not allowed in SUSE.''',
         'bad': [
             '/usr/lib*/python*/site-packages/test',
+            '/usr/lib*/python*/site-packages/tests',
         ],
     },
     {


### PR DESCRIPTION
just to make sure, we won't forget about it.