### PR TITLE
security checks: add link to openSUSE wiki to error message details

### DIFF
--- a/CheckDBUSServices.py
+++ b/CheckDBUSServices.py
@@ -52,5 +52,7 @@ if Config.info:
 'suse-dbus-unauthorized-service',
 """The package installs a DBUS system service file. If the package
 is intended for inclusion in any SUSE product please open a bug
-report to request review of the service by the security team.""",
+report to request review of the service by the security team. Please
+refer to https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs
+for more information.""",
 )

--- a/CheckPAMModules.py
+++ b/CheckPAMModules.py
@@ -45,5 +45,6 @@ if Config.info:
 'suse-pam-unauthorized-module',
 """The package installs a PAM module. If the package
 is intended for inclusion in any SUSE product please open a bug
-report to request review of the service by the security team.""",
+report to request review of the service by the security team.
+Please refer to https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs""",
 )

--- a/CheckPolkitPrivs.py
+++ b/CheckPolkitPrivs.py
@@ -146,24 +146,29 @@ class PolkitCheck(AbstractCheck.AbstractCheck):
 
 check = PolkitCheck()
 
+AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
+
 addDetails(
 'polkit-unauthorized-file',
 """If the package is intended for inclusion in any SUSE product
 please open a bug report to request review of the package by the
-security team""",
+security team. Please refer to {} for more information""".format(AUDIT_BUG_URL),
 
 'polkit-unauthorized-privilege',
 """The package allows unprivileged users to carry out privileged
 operations without authentication. This could cause security
 problems if not done carefully. If the package is intended for
 inclusion in any SUSE product please open a bug report to request
-review of the package by the security team""",
+review of the package by the security team. Please refer to {}
+for more information.""".format(AUDIT_BUG_URL),
 
 'polkit-untracked-privilege',
 """The privilege is not listed in /etc/polkit-default-privs.*
-which makes it harder for admins to find. If the package is intended
-for inclusion in any SUSE product please open a bug report to
-request review of the package by the security team""",
+which makes it harder for admins to find. Furthermore polkit
+authorization checks can easily introduce security issues. If the
+package is intended for inclusion in any SUSE product please open
+a bug report to request review of the package by the security team.
+Please refer to {} for more information.""".format(AUDIT_BUG_URL),
 
 'polkit-cant-acquire-privilege',
 """Usability can be improved by allowing users to acquire privileges

--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -237,22 +237,26 @@ class SUIDCheck(AbstractCheck.AbstractCheck):
 
 check = SUIDCheck()
 
+AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
+
 addDetails(
 'permissions-unauthorized-file',
 """If the package is intended for inclusion in any SUSE product
 please open a bug report to request review of the package by the
-security team""",
+security team. Please refer to {} for more
+information.""".format(AUDIT_BUG_URL),
 'permissions-symlink',
 """permissions handling for symlinks is useless. Please contact
-security@suse.de to remove the entry.""",
+security@suse.de to remove the entry. Please refer to {} for more
+information.""".format(AUDIT_BUG_URL),
 'permissions-dir-without-slash',
 """the entry in the permissions file refers to a directory. Please
 contact security@suse.de to append a slash to the entry in order to
-avoid security problems.""",
+avoid security problems. Please refer to {} for more information.""".format(AUDIT_BUG_URL),
 'permissions-file-as-dir',
 """the entry in the permissions file refers to a directory but the
 package actually contains a file. Please contact security@suse.de to
-remove the slash.""",
+remove the slash. Please refer to {} for more information.""".format(AUDIT_BUG_URL),
 'permissions-incorrect',
 """please use the %attr macro to set the correct permissions.""",
 'permissions-incorrect-owner',
@@ -260,15 +264,17 @@ remove the slash.""",
 'permissions-file-setuid-bit',
 """If the package is intended for inclusion in any SUSE product
 please open a bug report to request review of the program by the
-security team""",
+security team. Please refer to {} for more information.""".format(AUDIT_BUG_URL),
 'permissions-directory-setuid-bit',
 """If the package is intended for inclusion in any SUSE product
 please open a bug report to request review of the package by the
-security team""",
+security team. Please refer to {} for more
+information.""".format(AUDIT_BUG_URL),
 'permissions-world-writable',
 """If the package is intended for inclusion in any SUSE product
 please open a bug report to request review of the package by the
-security team""",
+security team. Please refer to {} for more
+information.""".format(AUDIT_BUG_URL),
 'permissions-fscaps',
 """Packaging file capabilities is currently not supported. Please
 use normal permissions instead. You may contact the security team to


### PR DESCRIPTION
This is supposed to improve the user friendliness so that packagers can
easily obtain more complete information about the security audit
process. This way the audit process documentation is also better
decoupled from the rpmlint error messages.