### PR TITLE
Handle '-n' option for %service_del_preun %service_del_postun

### DIFF
--- a/CheckSystemdInstall.py
+++ b/CheckSystemdInstall.py
@@ -42,8 +42,8 @@ class CheckSystemdInstall(AbstractCheck.AbstractCheck):
 
                 escaped_basename = re.escape(os.path.basename(fname))
                 PRE_POST_PATTERN = re.compile(r'for service in .*' + escaped_basename)
-                PREUN_PATTERN = re.compile(r'systemctl stop .*' + escaped_basename)
-                POSTUN_PATTERN = re.compile(r'systemctl try-restart .*' + escaped_basename)
+                PREUN_PATTERN = re.compile(r'systemctl --no-reload disable .*' + escaped_basename)
+                POSTUN_PATTERN = re.compile(r'(systemctl try-restart .*|# Restart of .*)' + escaped_basename)
 
                 for line in pre.split("\n"):
                     if PRE_POST_PATTERN.search(line):


### PR DESCRIPTION
The pre/postun macros expand differently, when the '-n' option is
set. Handle all variants of the scriptlets correctly.

Signed-off-by: Egbert Eich <eich@suse.com>