### PR TITLE
Add support to identify %tmpfiles_create used with just a basename

### DIFF
--- a/TmpFilesCheck.py
+++ b/TmpFilesCheck.py
@@ -5,6 +5,7 @@
 # Purpose       : Check systemd created tmpfiles are included in filelist
 
 import re
+import os.path
 
 from Filter import addDetails, printWarning
 import AbstractCheck
@@ -37,11 +38,16 @@ class TmpFilesCheck(AbstractCheck.AbstractCheck):
             if not stat.S_ISREG(pkgfile.mode):
                 printWarning(pkg, "tmpfile-not-regular-file", fn)
                 continue
+            basename = os.path.basename(fn)
 
             pattern = re.compile(
                 r'systemd-tmpfiles --create .*%s' % re.escape(fn))
-            if (not postin or not pattern.search(postin)) and \
-                    (not prein or not pattern.search(prein)):
+            pattern_basename = re.compile(
+                r'systemd-tmpfiles --create .*%s' % re.escape(basename))
+            if (not postin or (not pattern.search(postin) and
+                               not pattern_basename.search(postin)) and
+                    (not prein or (not pattern.search(prein) and
+                                   not pattern_basename.search(prein)))):
                 printWarning(pkg,
                              'postin-without-tmpfile-creation', fn)
 

--- a/TmpFilesCheck.py
+++ b/TmpFilesCheck.py
@@ -38,16 +38,12 @@ class TmpFilesCheck(AbstractCheck.AbstractCheck):
             if not stat.S_ISREG(pkgfile.mode):
                 printWarning(pkg, "tmpfile-not-regular-file", fn)
                 continue
-            basename = os.path.basename(fn)
 
+            basename = os.path.basename(fn)
             pattern = re.compile(
-                r'systemd-tmpfiles --create .*%s' % re.escape(fn))
-            pattern_basename = re.compile(
                 r'systemd-tmpfiles --create .*%s' % re.escape(basename))
-            if (not postin or (not pattern.search(postin) and
-                               not pattern_basename.search(postin)) and
-                    (not prein or (not pattern.search(prein) and
-                                   not pattern_basename.search(prein)))):
+            if (not postin or not pattern.search(postin)) and \
+                    (not prein or not pattern.search(prein)):
                 printWarning(pkg,
                              'postin-without-tmpfile-creation', fn)
 


### PR DESCRIPTION
Using %tmpfiles_create foo.conf (without the full path) is perfectly
valid but rpmlint was giving false postin-without-tmpfile-creation
warnings when used this way. Now it's recognized correctly.