### PR TITLE
CheckFilelist: Add /usr/libexec to set of good prefixes

### DIFF
--- a/CheckFilelist.py
+++ b/CheckFilelist.py
@@ -59,6 +59,7 @@ _goodprefixes = (
     '/usr/games/',
     '/usr/include/',
     '/usr/lib/',
+    '/usr/libexec/',
     '/usr/lib64/',
     '/usr/sbin/',
     '/usr/share/',


### PR DESCRIPTION
See this opensuse-packaging thread: https://lists.opensuse.org/opensuse-packaging/2019-07/msg00039.html