### PR TITLE
Cron whitelisting and some refactoring of security related checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyo
+__pycache__

--- a/CheckCronJobs.py
+++ b/CheckCronJobs.py
@@ -83,14 +83,15 @@ class CronCheck(AbstractCheck.AbstractCheck):
         )
 
         for f in files:
-            if f in pkg.ghostFiles():
-                continue
-
             for cron_dir in cron_dirs:
                 if f.startswith(cron_dir):
                     break
             else:
                 # no match
+                continue
+
+            if f in pkg.ghostFiles():
+                printError(pkg, 'cronjob-ghost-file', f)
                 continue
 
             entries = self.m_whitelist_entries.get(f, [])
@@ -142,6 +143,13 @@ for _id, desc in (
             """A cron job or cron job related file installed by this package changed
             in content. Please open a bug report to request follow-up review of the
             introduced changes by the security team. Please refer to {url} for more
-            information.""")
+            information."""
+        ),
+        (
+            'cronjob-ghost-file',
+            """A cron job path has been marked as %ghost file by this package.
+            This is not allowed as it is impossible to review. Please refer to
+            {url} for more information."""
+        )
 ):
     addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckCronJobs.py
+++ b/CheckCronJobs.py
@@ -1,0 +1,147 @@
+# vim: sw=4 ts=4 sts=4 et :
+#############################################################################
+# Author        : Matthias Gerstner
+# Purpose       : Enforce Whitelisting for cron jobs in /etc/cron.* directories
+#############################################################################
+
+import os
+import sys
+
+import AbstractCheck
+import Config
+import Whitelisting
+
+from Filter import addDetails, printError
+
+# this option is found in config files in /opt/testing/share/rpmlint/mini,
+# installed there by the rpmlint-mini package.
+WHITELIST_DIR = Config.getOption('WhitelistDataDir', [])
+
+
+class CronCheck(AbstractCheck.AbstractCheck):
+
+    def __init__(self):
+        AbstractCheck.AbstractCheck.__init__(self, "CheckCronJobs")
+
+        for wd in WHITELIST_DIR:
+            candidate = os.path.join(wd, "cron-whitelist.json")
+            if os.path.exists(candidate):
+                whitelist_path = candidate
+                break
+        else:
+            whitelist_path = None
+
+        self.m_check_configured = whitelist_path is not None
+
+        if not self.m_check_configured:
+            return
+
+        parser = Whitelisting.WhitelistParser(whitelist_path)
+        self.m_whitelist_entries = parser.parse()
+
+    def _getPrintPrefix(self):
+        """Returns a prefix for error / warning output."""
+        return self.__class__.__name__ + ":"
+
+    def _getErrorPrefix(self):
+        return self._getPrintPrefix() + " ERROR: "
+
+    def _getWarnPrefix(self):
+        return self._getPrintPrefix() + " WARN: "
+
+    def _printVerificationResults(self, verification_results):
+        """For the case of changed file digests this function prints the
+        encountered and expected digests and paths for diagnostic purposes."""
+
+        for result in verification_results:
+            if result.matches():
+                continue
+
+            print("{path}: expected {alg} digest {expected} but encountered {encountered}".format(
+                path=result.path(), alg=result.algorithm(),
+                expected=result.expected(), encountered=result.encountered()
+            ), file=sys.stderr)
+
+    def check(self, pkg):
+        """This is called by rpmlint to perform the cron check on the given
+        pkg."""
+
+        if pkg.isSource():
+            return
+        elif not self.m_check_configured:
+            # don't ruin the whole run if this check is not configured, this
+            # was hopefully intended by the user.
+            return
+
+        files = pkg.files()
+        cron_dirs = (
+            "/etc/cron.d/",
+            "/etc/cron.hourly/",
+            "/etc/cron.daily/",
+            "/etc/cron.weekly/",
+            "/etc/cron.monthly/"
+        )
+
+        for f in files:
+            if f in pkg.ghostFiles():
+                continue
+
+            for cron_dir in cron_dirs:
+                if f.startswith(cron_dir):
+                    break
+            else:
+                # no match
+                continue
+
+            entries = self.m_whitelist_entries.get(f, [])
+            wl_match = None
+            for entry in entries:
+                if entry.package() == pkg.name:
+                    wl_match = entry
+                    break
+            else:
+                # no whitelist entry exists for this file
+                printError(pkg, 'cronjob-unauthorized-file', f)
+                continue
+
+            # for the case that there's no match of digests, remember the most
+            # recent digest verification result for diagnosis output towards
+            # the user
+            diag_results = None
+
+            # check the newest (bottom) entry first it is more likely to match
+            # what we have
+            for audit in reversed(wl_match.audits()):
+                digest_matches, results = audit.compareDigests(pkg)
+
+                if digest_matches:
+                    break
+
+                if not diag_results:
+                    diag_results = results
+            else:
+                # none of the digest entries matched
+                self._printVerificationResults(diag_results)
+                printError(pkg, 'cronjob-changed-file', f)
+                continue
+
+
+# needs to be instantiated for the check to be registered with rpmlint
+check = CronCheck()
+
+AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
+
+for detail, desc in (
+        ('cronjob-unauthorized-file',
+        """A cron job rule file is installed by this package. If the package is
+        intended for inclusion in any SUSE product please open a bug report to request
+        review of the package by the security team. Please refer to {url} for more
+        information"""),
+        ('cronjob-changed-file',
+        """A cron job or cron job related file installed by this package changed
+        in content. Please open a bug report to request follow-up review of the
+        introduced changes by the security team. Please refer to {url} for more
+        information.""")
+    ):
+    addDetails(detail, desc.format(url = AUDIT_BUG_URL))
+

--- a/CheckCronJobs.py
+++ b/CheckCronJobs.py
@@ -129,19 +129,19 @@ class CronCheck(AbstractCheck.AbstractCheck):
 # needs to be instantiated for the check to be registered with rpmlint
 check = CronCheck()
 
-AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
-
-for detail, desc in (
-        ('cronjob-unauthorized-file',
-        """A cron job rule file is installed by this package. If the package is
-        intended for inclusion in any SUSE product please open a bug report to request
-        review of the package by the security team. Please refer to {url} for more
-        information"""),
-        ('cronjob-changed-file',
-        """A cron job or cron job related file installed by this package changed
-        in content. Please open a bug report to request follow-up review of the
-        introduced changes by the security team. Please refer to {url} for more
-        information.""")
-    ):
-    addDetails(detail, desc.format(url = AUDIT_BUG_URL))
-
+for _id, desc in (
+        (
+            'cronjob-unauthorized-file',
+            """A cron job rule file is installed by this package. If the package is
+            intended for inclusion in any SUSE product please open a bug report to request
+            review of the package by the security team. Please refer to {url} for more
+            information"""
+        ),
+        (
+            'cronjob-changed-file',
+            """A cron job or cron job related file installed by this package changed
+            in content. Please open a bug report to request follow-up review of the
+            introduced changes by the security team. Please refer to {url} for more
+            information.""")
+):
+    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckDBUSServices.py
+++ b/CheckDBUSServices.py
@@ -36,11 +36,12 @@ class DBUSServiceCheck(AbstractCheck.AbstractCheck):
         files = pkg.files()
 
         for f in files:
-            if f in pkg.ghostFiles():
-                continue
-
             for p in _dbus_system_paths:
                 if f.startswith(p):
+
+                    if f in pkg.ghostFiles():
+                        printError(pkig, "suse-dbus-ghost-service", f)
+                        continue
 
                     bn = f[len(p):]
                     if bn not in SERVICES_WHITELIST:
@@ -58,5 +59,11 @@ if Config.info:
             report to request review of the service by the security team. Please
             refer to {url} for more information."""
         ),
+        (
+            'suse-dbus-ghost-service',
+            """This package installs a DBUS system service marked as %ghost.
+            This is not allowed, since it is impossible to review. Please
+            refer to {url} for more information."""
+        )
     ):
         addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckDBUSServices.py
+++ b/CheckDBUSServices.py
@@ -1,4 +1,4 @@
-# vim:sw=4:et
+# vim: sw=4 et sts=4 ts=4 :
 #############################################################################
 # File          : CheckDBUSServices.py
 # Package       : rpmlint
@@ -10,6 +10,7 @@
 
 from Filter import *
 import AbstractCheck
+import Whitelisting
 
 SERVICES_WHITELIST = Config.getOption('DBUSServices.WhiteList', ())  # set of file names
 
@@ -49,11 +50,13 @@ class DBUSServiceCheck(AbstractCheck.AbstractCheck):
 check = DBUSServiceCheck()
 
 if Config.info:
-    addDetails(
-'suse-dbus-unauthorized-service',
-"""The package installs a DBUS system service file. If the package
-is intended for inclusion in any SUSE product please open a bug
-report to request review of the service by the security team. Please
-refer to https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs
-for more information.""",
-)
+    for _id, desc in (
+        (
+            'suse-dbus-unauthorized-service',
+            """The package installs a DBUS system service file. If the package
+            is intended for inclusion in any SUSE product please open a bug
+            report to request review of the service by the security team. Please
+            refer to {url} for more information."""
+        ),
+    ):
+        addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckPAMModules.py
+++ b/CheckPAMModules.py
@@ -29,11 +29,12 @@ class PAMModulesCheck(AbstractCheck.AbstractCheck):
         files = pkg.files()
 
         for f in files:
-            if f in pkg.ghostFiles():
-                continue
-
             m = pam_module_re.match(f)
             if m:
+                if f in pkg.ghostFiles():
+                    printError(pkg, 'suse-pam-ghost-module', f)
+                    continue
+
                 bn = m.groups()[0]
                 if bn not in PAM_WHITELIST:
                     printError(pkg, "suse-pam-unauthorized-module", bn)
@@ -51,5 +52,11 @@ if Config.info:
             report to request review of the service by the security team.
             Please refer to {url}"""
         ),
+        (
+            'suse-pam-ghost-module',
+            """The package installs a PAM module as %ghost file. This is not
+            allowed as it is impossible to review. For more information please
+            refer to {url} for more information."""
+        )
     ):
         addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckPAMModules.py
+++ b/CheckPAMModules.py
@@ -1,4 +1,4 @@
-# vim:sw=4:et
+# vim: sw=4 ts=4 sts=4 et :
 #############################################################################
 # File          : CheckPAMModules.py
 # Package       : rpmlint
@@ -9,6 +9,7 @@
 from Filter import *
 import AbstractCheck
 import re
+import Whitelisting
 
 PAM_WHITELIST = Config.getOption('PAMModules.WhiteList', ())  # set of file names
 
@@ -41,10 +42,14 @@ class PAMModulesCheck(AbstractCheck.AbstractCheck):
 check = PAMModulesCheck()
 
 if Config.info:
-    addDetails(
-'suse-pam-unauthorized-module',
-"""The package installs a PAM module. If the package
-is intended for inclusion in any SUSE product please open a bug
-report to request review of the service by the security team.
-Please refer to https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs""",
-)
+
+    for _id, desc in (
+        (
+            'suse-pam-unauthorized-module',
+            """The package installs a PAM module. If the package
+            is intended for inclusion in any SUSE product please open a bug
+            report to request review of the service by the security team.
+            Please refer to {url}"""
+        ),
+    ):
+        addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckPolkitPrivs.py
+++ b/CheckPolkitPrivs.py
@@ -267,14 +267,9 @@ class PolkitCheck(AbstractCheck.AbstractCheck):
             pkgs = self.rules.get(f, None)
             wl_entry = pkgs.get(pkg.name, None) if pkgs else None
 
-            # TODO: at the moment these are only warnings while we're newly
-            # implementing this feature.
-            # We should turn these into errors with badness - or change our
-            # enforcement procedure in OBS to not require this any more.
-
             if not pkgs or not wl_entry:
                 # no whitelist entry exists for this file
-                printWarning(pkg, 'polkit-unauthorized-rules', f)
+                printError(pkg, 'polkit-unauthorized-rules', f)
                 continue
 
             if wl_entry["skip-digest-check"]:
@@ -291,7 +286,7 @@ class PolkitCheck(AbstractCheck.AbstractCheck):
                     break
             else:
                 # none of the digest entries matched
-                printWarning(pkg, 'polkit-changed-rules', f)
+                printError(pkg, 'polkit-changed-rules', f)
                 continue
 
     def _checkDigest(self, pkg, path, digest_spec):

--- a/CheckPolkitPrivs.py
+++ b/CheckPolkitPrivs.py
@@ -14,6 +14,7 @@ import os
 import sys
 import json
 import hashlib
+import Whitelisting
 from xml.dom.minidom import parse
 
 POLKIT_PRIVS_WHITELIST = Config.getOption('PolkitPrivsWhiteList', ())   # set of file names
@@ -334,45 +335,51 @@ class PolkitCheck(AbstractCheck.AbstractCheck):
 
 check = PolkitCheck()
 
-AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
-
-addDetails(
-'polkit-unauthorized-file',
-"""A custom polkit rule file is installed by this package. If the package is
-intended for inclusion in any SUSE product please open a bug report to request
-review of the package by the security team. Please refer to {} for more
-information""".format(AUDIT_BUG_URL),
-
-'polkit-unauthorized-privilege',
-"""The package allows unprivileged users to carry out privileged
-operations without authentication. This could cause security
-problems if not done carefully. If the package is intended for
-inclusion in any SUSE product please open a bug report to request
-review of the package by the security team. Please refer to {}
-for more information.""".format(AUDIT_BUG_URL),
-
-'polkit-untracked-privilege',
-"""The privilege is not listed in /etc/polkit-default-privs.*
-which makes it harder for admins to find. Furthermore polkit
-authorization checks can easily introduce security issues. If the
-package is intended for inclusion in any SUSE product please open
-a bug report to request review of the package by the security team.
-Please refer to {} for more information.""".format(AUDIT_BUG_URL),
-
-'polkit-cant-acquire-privilege',
-"""Usability can be improved by allowing users to acquire privileges
-via authentication. Use e.g. 'auth_admin' instead of 'no' and make
-sure to define 'allow_any'. This is an issue only if the privilege
-is not listed in /etc/polkit-default-privs.*""",
-
-'polkit-unauthorized-rules',
-"""A polkit rules file installed by this package is not whitelisted in the
-polkit-whitelisting package. If the package is intended for inclusion in any
-SUSE product please open a bug report to request review of the package by the
-security team. Please refer to {} for more information.""".format(AUDIT_BUG_URL),
-
-'polkit-changed-rules',
-"""A polkit rules file installed by this package changed in content. Please
-open a bug report to request follow-up review of the introduced changes by
-the security team. Please refer to {} for more information.""".format(AUDIT_BUG_URL),
-)
+for _id, desc in (
+        (
+            'polkit-unauthorized-file',
+            """A custom polkit rule file is installed by this package. If the package is
+            intended for inclusion in any SUSE product please open a bug report to request
+            review of the package by the security team. Please refer to {url} for more
+            information"""
+        ),
+        (
+            'polkit-unauthorized-privilege',
+            """The package allows unprivileged users to carry out privileged
+            operations without authentication. This could cause security
+            problems if not done carefully. If the package is intended for
+            inclusion in any SUSE product please open a bug report to request
+            review of the package by the security team. Please refer to {url}
+            for more information."""
+        ),
+        (
+            'polkit-untracked-privilege',
+            """The privilege is not listed in /etc/polkit-default-privs.*
+            which makes it harder for admins to find. Furthermore polkit
+            authorization checks can easily introduce security issues. If the
+            package is intended for inclusion in any SUSE product please open
+            a bug report to request review of the package by the security team.
+            Please refer to {url} for more information."""
+        ),
+        (
+            'polkit-cant-acquire-privilege',
+            """Usability can be improved by allowing users to acquire privileges
+            via authentication. Use e.g. 'auth_admin' instead of 'no' and make
+            sure to define 'allow_any'. This is an issue only if the privilege
+            is not listed in /etc/polkit-default-privs.*"""
+        ),
+        (
+            'polkit-unauthorized-rules',
+            """A polkit rules file installed by this package is not whitelisted in the
+            polkit-whitelisting package. If the package is intended for inclusion in any
+            SUSE product please open a bug report to request review of the package by the
+            security team. Please refer to {url} for more information."""
+        ),
+        (
+            'polkit-changed-rules',
+            """A polkit rules file installed by this package changed in content. Please
+            open a bug report to request follow-up review of the introduced changes by
+            the security team. Please refer to {url} for more information."""
+        )
+):
+    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckPolkitPrivs.py
+++ b/CheckPolkitPrivs.py
@@ -1,4 +1,4 @@
-# vim:sw=4:et
+# vim: sw=4 et sts=4 ts=4 :
 #############################################################################
 # File          : CheckPolkitPrivs.py
 # Package       : rpmlint

--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -309,7 +309,7 @@ for _id, desc in (
         ),
         (
             'permissions-missing-requires',
-            """Please add \"PreReq: permissions\""""
+            """Please add 'PreReq: permissions'"""
         ),
         (
             'permissions-missing-verifyscript',

--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -84,14 +84,15 @@ class SUIDCheck(AbstractCheck.AbstractCheck):
 
         permfiles = {}
         # first pass, find and parse permissions.d files
+        prefix = "/etc/permissions.d/"
         for f in files:
-            if f.startswith("/etc/permissions.d/"):
+            if f.startswith(prefix):
 
                 if f in pkg.ghostFiles():
                     printError(pkg, 'polkit-ghost-file', f)
                     continue
 
-                bn = f[19:]
+                bn = f[len(prefix):]
                 if bn not in _permissions_d_whitelist:
                     printError(pkg, "permissions-unauthorized-file", f)
 

--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -1,4 +1,4 @@
-# vim:sw=4:et
+# vim: sw=4 et sts=4 ts=4 :
 #############################################################################
 # File          : CheckSUIDPermissions.py
 # Package       : rpmlint
@@ -10,6 +10,7 @@ from __future__ import print_function
 
 from Filter import printWarning, printError, printInfo, addDetails
 import AbstractCheck
+import Whitelisting
 import os
 import re
 import rpm
@@ -240,57 +241,84 @@ class SUIDCheck(AbstractCheck.AbstractCheck):
 
 check = SUIDCheck()
 
-AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
-
-addDetails(
-'permissions-unauthorized-file',
-"""If the package is intended for inclusion in any SUSE product
-please open a bug report to request review of the package by the
-security team. Please refer to {} for more
-information.""".format(AUDIT_BUG_URL),
-'permissions-symlink',
-"""permissions handling for symlinks is useless. Please contact
-security@suse.de to remove the entry. Please refer to {} for more
-information.""".format(AUDIT_BUG_URL),
-'permissions-dir-without-slash',
-"""the entry in the permissions file refers to a directory. Please
-contact security@suse.de to append a slash to the entry in order to
-avoid security problems. Please refer to {} for more information.""".format(AUDIT_BUG_URL),
-'permissions-file-as-dir',
-"""the entry in the permissions file refers to a directory but the
-package actually contains a file. Please contact security@suse.de to
-remove the slash. Please refer to {} for more information.""".format(AUDIT_BUG_URL),
-'permissions-incorrect',
-"""please use the %attr macro to set the correct permissions.""",
-'permissions-incorrect-owner',
-"""please use the %attr macro to set the correct ownership.""",
-'permissions-file-setuid-bit',
-"""If the package is intended for inclusion in any SUSE product
-please open a bug report to request review of the program by the
-security team. Please refer to {} for more information.""".format(AUDIT_BUG_URL),
-'permissions-directory-setuid-bit',
-"""If the package is intended for inclusion in any SUSE product
-please open a bug report to request review of the package by the
-security team. Please refer to {} for more
-information.""".format(AUDIT_BUG_URL),
-'permissions-world-writable',
-"""If the package is intended for inclusion in any SUSE product
-please open a bug report to request review of the package by the
-security team. Please refer to {} for more
-information.""".format(AUDIT_BUG_URL),
-'permissions-fscaps',
-"""Packaging file capabilities is currently not supported. Please
-use normal permissions instead. You may contact the security team to
-request an entry that sets capabilities in /etc/permissions
-instead.""",
-'permissions-missing-postin',
-"""Please add an appropriate %post section""",
-'permissions-missing-requires',
-"""Please add \"PreReq: permissions\"""",
-'permissions-missing-verifyscript',
-"""Please add a %verifyscript section""",
-'permissions-suseconfig-obsolete',
-"""The %run_permissions macro calls SuSEconfig which sets permissions for all
-files in the system. Please use %set_permissions <filename> instead
-to only set permissions for files contained in this package""",
-)
+for _id, desc in (
+        (
+            'permissions-unauthorized-file',
+            """If the package is intended for inclusion in any SUSE product
+            please open a bug report to request review of the package by the
+            security team. Please refer to {url} for more
+            information."""
+        ),
+        (
+            'permissions-symlink',
+            """permissions handling for symlinks is useless. Please contact
+            security@suse.de to remove the entry. Please refer to {url} for more
+            information."""
+        ),
+        (
+            'permissions-dir-without-slash',
+            """the entry in the permissions file refers to a directory. Please
+            contact security@suse.de to append a slash to the entry in order to
+            avoid security problems. Please refer to {url} for more information."""
+        ),
+        (
+            'permissions-file-as-dir',
+            """the entry in the permissions file refers to a directory but the
+            package actually contains a file. Please contact security@suse.de to
+            remove the slash. Please refer to {url} for more information."""
+        ),
+        (
+            'permissions-incorrect',
+            """please use the %attr macro to set the correct permissions."""
+        ),
+        (
+            'permissions-incorrect-owner',
+            """please use the %attr macro to set the correct ownership."""
+        ),
+        (
+            'permissions-file-setuid-bit',
+            """If the package is intended for inclusion in any SUSE product
+            please open a bug report to request review of the program by the
+            security team. Please refer to {url} for more information."""
+        ),
+        (
+            'permissions-directory-setuid-bit',
+            """If the package is intended for inclusion in any SUSE product
+            please open a bug report to request review of the package by the
+            security team. Please refer to {url} for more
+            information."""
+        ),
+        (
+            'permissions-world-writable',
+            """If the package is intended for inclusion in any SUSE product
+            please open a bug report to request review of the package by the
+            security team. Please refer to {url} for more
+            information."""
+        ),
+        (
+            'permissions-fscaps',
+            """Packaging file capabilities is currently not supported. Please
+            use normal permissions instead. You may contact the security team to
+            request an entry that sets capabilities in /etc/permissions
+            instead.""",
+        ),
+        (
+            'permissions-missing-postin',
+            """Please add an appropriate %post section"""
+        ),
+        (
+            'permissions-missing-requires',
+            """Please add \"PreReq: permissions\""""
+        ),
+        (
+            'permissions-missing-verifyscript',
+            """Please add a %verifyscript section"""
+        ),
+        (
+            'permissions-suseconfig-obsolete',
+            """The %run_permissions macro calls SuSEconfig which sets permissions for all
+            files in the system. Please use %set_permissions <filename> instead
+            to only set permissions for files contained in this package""",
+        )
+):
+    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -85,10 +85,11 @@ class SUIDCheck(AbstractCheck.AbstractCheck):
         permfiles = {}
         # first pass, find and parse permissions.d files
         for f in files:
-            if f in pkg.ghostFiles():
-                continue
-
             if f.startswith("/etc/permissions.d/"):
+
+                if f in pkg.ghostFiles():
+                    printError(pkg, 'polkit-ghost-file', f)
+                    continue
 
                 bn = f[19:]
                 if bn not in _permissions_d_whitelist:
@@ -319,6 +320,12 @@ for _id, desc in (
             """The %run_permissions macro calls SuSEconfig which sets permissions for all
             files in the system. Please use %set_permissions <filename> instead
             to only set permissions for files contained in this package""",
+        ),
+        (
+            'permissions-ghostfile',
+            """This package installs a permissions file as a %ghost file. This
+            is not allowed as it is impossible to review. Please refer to
+            {url} for more information."""
         )
 ):
     addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/Whitelisting.py
+++ b/Whitelisting.py
@@ -1,0 +1,280 @@
+# vim: sw=4 ts=4 sts=4 et :
+#############################################################################
+# Author        : Matthias Gerstner
+# Purpose       : reusable code for dealing with security whitelistings
+#############################################################################
+
+import os
+import json
+import hashlib
+
+
+class DigestVerificationResult(object):
+    """This type represents the result of a digest verification as returned
+    from AuditEntry.compareDigests()."""
+
+    def __init__(self, path, alg, expected, encountered):
+
+        self.m_path = path
+        self.m_alg = alg
+        self.m_expected = expected
+        self.m_encountered = encountered
+
+    def path(self):
+        return self.m_path
+
+    def algorithm(self):
+        return self.m_alg
+
+    def matches(self):
+        """Returns a boolean whether the encountered digest matches the
+        expected digest."""
+        return self.m_expected == self.m_encountered
+
+    def expected(self):
+        return self.m_expected
+
+    def encountered(self):
+        return self.m_encountered
+
+
+class AuditEntry(object):
+    """This object represents a single audit entry as found in a whitelisting
+    entry like:
+
+    "bsc#1234": {
+        "comment": "some comment",
+        "digests": {
+            "/some/file": "<alg>:<digest>",
+            ...
+        }
+    }
+
+    """
+
+    def __init__(self, bug):
+
+        self.m_bug = bug
+        self._verifyBugNr()
+        self.m_comment = ""
+        self.m_digests = {}
+
+    def bug(self):
+        return self.m_bug
+
+    def setComment(self, comment):
+        self.m_comment = comment
+
+    def comment(self):
+        return self.m_comment
+
+    def setDigests(self, digests):
+        for path, digest in digests.items():
+            self._verifyPath(path)
+            self._verifyDigestSyntax(digest)
+
+        self.m_digests = digests
+
+    def digests(self):
+        """Returns a dictionary specifying file paths and their whitelisted
+        digests. The digests are suitable for the
+        Python hashlib module. They're of the form '<alg>:<hexdigest>'. As a
+        special case the digest entry can be 'skip:<none>' which indicates
+        that no digest verification should be performed and the file is
+        acceptable regardless of its contents."""
+        return self.m_digests
+
+    def isSkipDigest(self, digest):
+        """Returns whether the given digest entry denotes the special "skip
+        digest" case which means not to check the file digest at all."""
+        return digest == 'skip:<none>'
+
+    def compareDigests(self, pkg):
+        """Compares the digests recorded in this AuditEntry against the actual
+        files coming from the given rpmlint @pkg. Returns a tuple of
+        (boolean, [DigestVerificationResult, ...]). The boolean indicates the
+        overall verification result, while the list of
+        DigestVerificationResult entries provides detailed information about
+        the encountered data. Any "skip digest" entries will be ignored and
+        not be included in the result list."""
+
+        results = []
+
+        # NOTE: syntax and algorithm validity of stored digests was already
+        # checked in setDigests() so we can skip the respective error handling
+        # here.
+
+        for path, digest in self.digests().items():
+            if self.isSkipDigest(digest):
+                continue
+
+            alg, digest = digest.split(':', 1)
+
+            try:
+                h = hashlib.new(alg)
+
+                with open(pkg.dirName() + path, 'rb') as fd:
+                    while True:
+                        chunk = fd.read(4096)
+                        if not chunk:
+                            break
+
+                        h.update(chunk)
+
+                    encountered = h.hexdigest()
+            except IOError as e:
+                encountered = "error:" + str(e)
+
+            dig_res = DigestVerificationResult(path, alg, digest, encountered)
+            results.append(dig_res)
+
+        return (all([res.matches() for res in results]), results)
+
+    def _verifyBugNr(self):
+        """Perform some sanity checks on the bug nr associated with this audit
+        entry."""
+
+        parts = self.m_bug.split('#')
+
+        if len(parts) != 2 or \
+                parts[0] not in ("bsc", "boo", "bnc") or \
+                not parts[1].isdigit():
+            raise Exception("Bad bug nr# '{}'".format(self.m_bug))
+
+    def _verifyDigestSyntax(self, digest):
+        if self.isSkipDigest(digest):
+            return
+
+        parts = digest.split(':')
+        if len(parts) != 2:
+            raise Exception("Bad digest specification " + digest)
+
+        alg, hexdigest = parts
+
+        try:
+            hashlib.new(alg)
+        except ValueError:
+            raise Exception("Bad digest algorithm in " + digest)
+
+    def _verifyPath(self, path):
+        if not path.startswith(os.path.sep):
+            raise Exception("Bad whitelisting path " + path)
+
+
+class WhitelistEntry(object):
+    """This object represents a single whitelisting entry like:
+
+    "somepackage" {
+        "audits": {
+            ...
+        }
+    },
+    """
+
+    def __init__(self, package):
+        self.m_package = package
+        # a list of AuditEntry objects associated with this whitelisting entry
+        self.m_audits = []
+
+    def package(self):
+        return self.m_package
+
+    def addAudit(self, audit):
+        self.m_audits.append(audit)
+
+    def audits(self):
+        return self.m_audits
+
+
+class WhitelistParser(object):
+    """This type knows how to parse the JSON whitelisting format."""
+
+    def __init__(self, wl_path):
+        """Creates a new instance of WhitelistParser that operates on
+        @wl_path."""
+
+        self.m_path = wl_path
+
+    def parse(self):
+        """Parses the whitelisting file and returns a dictionary of the
+        following structure:
+
+        {
+            "path/to/file": [WhitelistEntry(), ...],
+            ...
+        }
+
+        Since a single path might be claimed by more than one package the
+        values of the dictionary are lists, to cover for this possibility.
+        """
+
+        ret = {}
+
+        try:
+            with open(self.m_path, 'r') as fd:
+                data = json.load(fd)
+
+                for pkg, config in data.items():
+                    entry = self._parseWhitelistEntry(pkg, config)
+                    if not entry:
+                        # soft error, continue parsing
+                        continue
+                    for a in entry.audits():
+                        for path in a.digests():
+                            entries = ret.setdefault(path, [])
+                            entries.append(entry)
+        except Exception as e:
+            raise Exception(self._getErrorPrefix() + ": Failed to parse JSON file: " + str(e))
+
+        return ret
+
+    def _parseWhitelistEntry(self, package, config):
+        """Parses a single JSON whitelist entry returns a WhitelistEntry()
+        object for it. On non-critical error conditions None is returned,
+        otherwise an exception is raised."""
+
+        ret = WhitelistEntry(package)
+
+        audits = config.get("audits", {})
+
+        if not audits:
+            raise Exception(self._getErrorPrefix() + "no 'audits' entries for package {}".format(package))
+
+        for bug, data in audits.items():
+            try:
+                audit = self._parseAuditEntry(bug, data)
+            except Exception as e:
+                raise Exception(self._getErrorPrefix() + "Failed to parse audit entries: " + str(e))
+
+            if not audit:
+                # soft error, continue parsing
+                continue
+            ret.addAudit(audit)
+
+        return ret
+
+    def _parseAuditEntry(self, bug, data):
+        """Parses a single JSON audit sub-entry returns an AuditEntry() object
+        for it. On non-critical error conditions None is returned, otherwise
+        an exception is raised"""
+
+        ret = AuditEntry(bug)
+
+        comment = data.get("comment", None)
+        if comment:
+            ret.setComment(comment)
+
+        digests = data.get("digests", {})
+
+        if not digests:
+            raise Exception(self._getErrorPrefix() + "no 'digests' entry for '{}'".format(bug))
+
+        ret.setDigests(digests)
+
+        return ret
+
+    def _getErrorPrefix(self):
+        return self.m_path + ": ERROR: "
+
+    def _getWarnPrefix(self):
+        return self.m_path + ": WARN: "

--- a/Whitelisting.py
+++ b/Whitelisting.py
@@ -115,6 +115,10 @@ class AuditEntry(object):
             try:
                 h = hashlib.new(alg)
 
+                # NOTE: this path is dynamic and rpmlint unpacks the RPM
+                # contents into a temporary directory even when outside the
+                # build environment i.e. the file content should always be
+                # available to us.
                 with open(pkg.dirName() + path, 'rb') as fd:
                     while True:
                         chunk = fd.read(4096)

--- a/Whitelisting.py
+++ b/Whitelisting.py
@@ -8,6 +8,8 @@ import os
 import json
 import hashlib
 
+AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
+
 
 class DigestVerificationResult(object):
     """This type represents the result of a digest verification as returned


### PR DESCRIPTION
This adds a new more generic approach to implement whitelisting restrictions. Along with it a new check for cron job files is introduced. I also tried so harmonize the code of the security related checks a bit.

The new check won't be active right away. There's currently no badness configured, also rpmlint/config needs to be adjusted and the new whitelisting file needs to be embedded into rpmlint-mini.