### PR TITLE
CheckSUIDPermissions.py: fix permissions.d checks

### DIFF
--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -116,8 +116,8 @@ class SUIDCheck(AbstractCheck.AbstractCheck):
         for f in permfiles:
             # check for a .secure file first, falling back to the plain file
             for path in self._paths_to(f + '.secure', f):
-                if os.path.exists(path):
-                    self._parsefile(path)
+                if path in files:
+                    self._parsefile(pkg.dirName() + path)
                     break
 
         need_set_permissions = False


### PR DESCRIPTION
Verified to not complain against `server:mail/postfix`.

The old code already had the broken `os.path.exists` call, but only for checking if a `.secure` variant exists. The changed code called it for both, and so it never actually parsed any `permissions.d` file. And our tests didn't cover the case of an actually whitelisted `permissions.d` file either.

@jsegitz I can't push this myself.