### PR TITLE
fix CheckFilelist.py python3

### DIFF
--- a/CheckFilelist.py
+++ b/CheckFilelist.py
@@ -426,7 +426,7 @@ class FilelistCheck(AbstractCheck.AbstractCheck):
         invalidopt = set()
 
         isSUSE = (pkg.header[RPMTAG_VENDOR] and
-                  b'SUSE' in pkg.header[RPMTAG_VENDOR])
+                  'SUSE' in pkg.header[RPMTAG_VENDOR])
 
         # the checks here only warn about a directory once rather
         # than reporting potentially hundreds of files individually


### PR DESCRIPTION
this is currently fixed in OBS through (the last hunk of) `rpm415-workaround.diff` instead of here.