### PR TITLE
Do not try to open tmpfiles if marked as ghost

### DIFF
--- a/TmpFilesCheck.py
+++ b/TmpFilesCheck.py
@@ -39,6 +39,9 @@ class TmpFilesCheck(AbstractCheck.AbstractCheck):
                 printWarning(pkg, "tmpfile-not-regular-file", fn)
                 continue
 
+            if pkgfile.is_ghost:
+                continue
+
             basename = os.path.basename(fn)
             pattern = re.compile(
                 r'systemd-tmpfiles --create .*%s' % re.escape(basename))


### PR DESCRIPTION
This is a problem if tmpfiles below /usr/lib/tnpfiles.d/ are created dynamically  within rpm scriptlets as the content depends on e.g. the current hardware and modules loaded

Signed-off-by: Werner Fink <werner@suse.de>