### PR TITLE
CheckSUIDPermissions: remove dead permissions.d whitelisting entry

### DIFF
--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -18,15 +18,10 @@ import sys
 import stat
 
 _permissions_d_whitelist = (
-    "lprng",
-    "lprng.paranoid",
-    "mail-server",
-    "mail-server.paranoid",
     "postfix",
     "postfix.paranoid",
     "sendmail",
     "sendmail.paranoid",
-    "squid",
     "texlive",
     "texlive.texlive",
     "otrs",  # bsc#1118049


### PR DESCRIPTION
These entries are no longer shipped in Factory.