### PR TITLE
Extend SONAME/libname check with stricter character class rules

### DIFF
--- a/LibraryPolicyCheck.py
+++ b/LibraryPolicyCheck.py
@@ -286,13 +286,13 @@ _essential_dependencies = (
 
 def libname_from_soname(soname):
     libname = str.split(soname, '.so.')
-    if len(libname) == 2:
-        if libname[0][-1:].isdigit():
-            libname = '-'.join(libname)
-        else:
-            libname = ''.join(libname)
-    else:
+    if len(libname) != 2:
         libname = soname[:-3]
+    elif (libname[0][-1:].isdigit() and libname[1][0].isdigit()) or \
+         (libname[0][-1:].isalpha() and libname[1][0].isalpha()):
+        libname = '-'.join(libname)
+    else:
+        libname = ''.join(libname)
     libname = libname.replace('.', '_')
     return libname
 


### PR DESCRIPTION
Given libabc.so.suse0, rpmlint falsely complains about the chosen
package name libabc-suse0:

libabc-suse0.x86_64: E: shlib-policy-name-error (Badness: 10000) libabcsuse0