### PR TITLE
Introduce new metadata based whitelisting checks

### DIFF
--- a/CheckCronJobs.py
+++ b/CheckCronJobs.py
@@ -4,40 +4,20 @@
 # Purpose       : Enforce Whitelisting for cron jobs in /etc/cron.* directories
 #############################################################################
 
-import os
-
-import AbstractCheck
-import Config
 import Whitelisting
-
-from Filter import addDetails
-
-# this option is found in config files in /opt/testing/share/rpmlint/mini,
-# installed there by the rpmlint-mini package.
-WHITELIST_DIR = Config.getOption('WhitelistDataDir', [])
+from WhitelistingCheckBase import WhitelistingCheckBase
 
 
-class CronCheck(AbstractCheck.AbstractCheck):
+class CronCheck(WhitelistingCheckBase):
 
     def __init__(self):
-        AbstractCheck.AbstractCheck.__init__(self, "CheckCronJobs")
+        super().__init__("CheckCronJobs", "cron-whitelist.json")
 
-        for wd in WHITELIST_DIR:
-            candidate = os.path.join(wd, "cron-whitelist.json")
-            if os.path.exists(candidate):
-                whitelist_path = candidate
-                break
-        else:
-            whitelist_path = None
-
-        self.m_check_configured = whitelist_path is not None
-
-        if not self.m_check_configured:
-            return
+    def setupChecker(self, whitelist_path):
 
         parser = Whitelisting.DigestWhitelistParser(whitelist_path)
         whitelist_entries = parser.parse()
-        self.m_wl_checker = Whitelisting.DigestWhitelistChecker(
+        return Whitelisting.DigestWhitelistChecker(
             whitelist_entries,
             restricted_paths=(
                 "/etc/cron.d/", "/etc/cron.hourly/", "/etc/cron.daily/",
@@ -49,27 +29,6 @@ class CronCheck(AbstractCheck.AbstractCheck):
                 "ghost": "cronjob-ghost-file"
             }
         )
-
-    def _getPrintPrefix(self):
-        """Returns a prefix for error / warning output."""
-        return self.__class__.__name__ + ":"
-
-    def _getErrorPrefix(self):
-        return self._getPrintPrefix() + " ERROR: "
-
-    def _getWarnPrefix(self):
-        return self._getPrintPrefix() + " WARN: "
-
-    def check(self, pkg):
-        """This is called by rpmlint to perform the cron check on the given
-        pkg."""
-
-        if not self.m_check_configured:
-            # don't ruin the whole run if this check is not configured, this
-            # was hopefully intended by the user.
-            return
-
-        self.m_wl_checker.check(pkg)
 
 
 # needs to be instantiated for the check to be registered with rpmlint

--- a/CheckCronJobs.py
+++ b/CheckCronJobs.py
@@ -75,26 +75,20 @@ class CronCheck(AbstractCheck.AbstractCheck):
 # needs to be instantiated for the check to be registered with rpmlint
 check = CronCheck()
 
-for _id, desc in (
-        (
-            'cronjob-unauthorized-file',
-            """A cron job file is installed by this package. If the package is
-            intended for inclusion in any SUSE product please open a bug report to request
-            review of the package by the security team. Please refer to {url} for more
-            information"""
-        ),
-        (
-            'cronjob-changed-file',
-            """A cron job or cron job related file installed by this package changed
-            in content. Please open a bug report to request follow-up review of the
-            introduced changes by the security team. Please refer to {url} for more
-            information."""
-        ),
-        (
-            'cronjob-ghost-file',
-            """A cron job path has been marked as %ghost file by this package.
-            This is not allowed as it is impossible to review. Please refer to
-            {url} for more information."""
-        )
-):
-    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))
+Whitelisting.registerErrorDetails((
+    (
+        'cronjob-unauthorized-file',
+        """A cron job file is installed by this package. {review_needed_text}"""
+    ),
+    (
+        'cronjob-changed-file',
+        """A cron job or cron job related file installed by this package changed
+        in content. {followup_needed_text}"""
+    ),
+    (
+        'cronjob-ghost-file',
+        """A cron job path has been marked as %ghost file by this package.
+        This is not allowed as it is impossible to review. Please refer to
+        {url} for more information."""
+    )
+))

--- a/CheckCronJobs.py
+++ b/CheckCronJobs.py
@@ -35,9 +35,9 @@ class CronCheck(AbstractCheck.AbstractCheck):
         if not self.m_check_configured:
             return
 
-        parser = Whitelisting.WhitelistParser(whitelist_path)
+        parser = Whitelisting.DigestWhitelistParser(whitelist_path)
         whitelist_entries = parser.parse()
-        self.m_wl_checker = Whitelisting.WhitelistChecker(
+        self.m_wl_checker = Whitelisting.DigestWhitelistChecker(
             whitelist_entries,
             restricted_paths=(
                 "/etc/cron.d/", "/etc/cron.hourly/", "/etc/cron.daily/",

--- a/CheckDBUSServices.py
+++ b/CheckDBUSServices.py
@@ -51,19 +51,16 @@ class DBUSServiceCheck(AbstractCheck.AbstractCheck):
 check = DBUSServiceCheck()
 
 if Config.info:
-    for _id, desc in (
+    Whitelisting.registerErrorDetails((
         (
             'suse-dbus-unauthorized-service',
-            """The package installs a DBUS system service file. If the package
-            is intended for inclusion in any SUSE product please open a bug
-            report to request review of the service by the security team. Please
-            refer to {url} for more information."""
+            """The package installs a DBUS system service file.
+            {review_needed_text}"""
         ),
         (
             'suse-dbus-ghost-service',
             """This package installs a DBUS system service marked as %ghost.
-            This is not allowed, since it is impossible to review. Please
-            refer to {url} for more information."""
+            {ghost_encountered_text}
+            """
         )
-    ):
-        addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))
+    ))

--- a/CheckDeviceFiles.py
+++ b/CheckDeviceFiles.py
@@ -10,8 +10,6 @@ import AbstractCheck
 import Config
 import Whitelisting
 
-from Filter import addDetails
-
 # this option is found in config files in /opt/testing/share/rpmlint/mini,
 # installed there by the rpmlint-mini package.
 WHITELIST_DIR = Config.getOption('WhitelistDataDir', [])
@@ -63,20 +61,17 @@ class DeviceFilesCheck(AbstractCheck.AbstractCheck):
 # needs to be instantiated for the check to be registered with rpmlint
 check = DeviceFilesCheck()
 
-for _id, desc in (
-        (
-            'device-unauthorized-file',
-            """A device file is installed by this package. If the package is
-            intended for inclusion in any SUSE product please open a bug
-            report to request review of the package by the security team.
-            Please refer to {url} for more information"""
-        ),
-        (
-            'device-mismatched-attrs',
-            """A device file doesn't match the expected file properties.
-            Please open a bug report to request follow-up review of the
-            introduced changes by the security team. Please refer to {url} for
-            more information."""
-        )
-):
-    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))
+Whitelisting.registerErrorDetails((
+    (
+        'device-unauthorized-file',
+        """A device file is installed by this package.
+        {review_needed_text}"""
+    ),
+    (
+        'device-mismatched-attrs',
+        """A device file doesn't match the expected file properties.
+        Please open a bug report to request follow-up review of the
+        introduced changes by the security team. Please refer to {url} for
+        more information."""
+    )
+))

--- a/CheckDeviceFiles.py
+++ b/CheckDeviceFiles.py
@@ -4,38 +4,20 @@
 # Purpose       : Enforce Whitelisting for device files
 #############################################################################
 
-import os
-
-import AbstractCheck
-import Config
 import Whitelisting
-
-# this option is found in config files in /opt/testing/share/rpmlint/mini,
-# installed there by the rpmlint-mini package.
-WHITELIST_DIR = Config.getOption('WhitelistDataDir', [])
+from WhitelistingCheckBase import WhitelistingCheckBase
 
 
-class DeviceFilesCheck(AbstractCheck.AbstractCheck):
+class DeviceFilesCheck(WhitelistingCheckBase):
 
     def __init__(self):
-        AbstractCheck.AbstractCheck.__init__(self, "CheckDeviceFiles")
+        super().__init__("CheckDeviceFiles", "device-files-whitelist.json")
 
-        for wd in WHITELIST_DIR:
-            candidate = os.path.join(wd, "device-files-whitelist.json")
-            if os.path.exists(candidate):
-                whitelist_path = candidate
-                break
-        else:
-            whitelist_path = None
-
-        self.m_check_configured = whitelist_path is not None
-
-        if not self.m_check_configured:
-            return
+    def setupChecker(self, whitelist_path):
 
         parser = Whitelisting.MetaWhitelistParser(whitelist_path)
         whitelist_entries = parser.parse()
-        self.m_wl_checker = Whitelisting.MetaWhitelistChecker(
+        return Whitelisting.MetaWhitelistChecker(
             whitelist_entries,
             error_map={
                 "unauthorized": "device-unauthorized-file",
@@ -46,16 +28,6 @@ class DeviceFilesCheck(AbstractCheck.AbstractCheck):
             # regardless the mode we want to catch all device files
             restricted_mode=0o7777
         )
-
-    def check(self, pkg):
-        """This is called by rpmlint to perform the check on the given pkg."""
-
-        if not self.m_check_configured:
-            # don't ruin the whole run if this check is not configured, this
-            # was hopefully intended by the user.
-            return
-
-        self.m_wl_checker.check(pkg)
 
 
 # needs to be instantiated for the check to be registered with rpmlint

--- a/CheckDeviceFiles.py
+++ b/CheckDeviceFiles.py
@@ -1,0 +1,82 @@
+# vim: sw=4 ts=4 sts=4 et :
+#############################################################################
+# Author        : Matthias Gerstner
+# Purpose       : Enforce Whitelisting for device files
+#############################################################################
+
+import os
+
+import AbstractCheck
+import Config
+import Whitelisting
+
+from Filter import addDetails
+
+# this option is found in config files in /opt/testing/share/rpmlint/mini,
+# installed there by the rpmlint-mini package.
+WHITELIST_DIR = Config.getOption('WhitelistDataDir', [])
+
+
+class DeviceFilesCheck(AbstractCheck.AbstractCheck):
+
+    def __init__(self):
+        AbstractCheck.AbstractCheck.__init__(self, "CheckDeviceFiles")
+
+        for wd in WHITELIST_DIR:
+            candidate = os.path.join(wd, "device-files-whitelist.json")
+            if os.path.exists(candidate):
+                whitelist_path = candidate
+                break
+        else:
+            whitelist_path = None
+
+        self.m_check_configured = whitelist_path is not None
+
+        if not self.m_check_configured:
+            return
+
+        parser = Whitelisting.MetaWhitelistParser(whitelist_path)
+        whitelist_entries = parser.parse()
+        self.m_wl_checker = Whitelisting.MetaWhitelistChecker(
+            whitelist_entries,
+            error_map={
+                "unauthorized": "device-unauthorized-file",
+                "mismatch": "device-mismatched-attrs",
+            },
+            # we are interested in any device files
+            restricted_types=("c", "b"),
+            # regardless the mode we want to catch all device files
+            restricted_mode=0o7777
+        )
+
+    def check(self, pkg):
+        """This is called by rpmlint to perform the check on the given pkg."""
+
+        if not self.m_check_configured:
+            # don't ruin the whole run if this check is not configured, this
+            # was hopefully intended by the user.
+            return
+
+        self.m_wl_checker.check(pkg)
+
+
+# needs to be instantiated for the check to be registered with rpmlint
+check = DeviceFilesCheck()
+
+for _id, desc in (
+        (
+            'device-unauthorized-file',
+            """A device file is installed by this package. If the package is
+            intended for inclusion in any SUSE product please open a bug
+            report to request review of the package by the security team.
+            Please refer to {url} for more information"""
+        ),
+        (
+            'device-mismatched-attrs',
+            """A device file doesn't match the expected file properties.
+            Please open a bug report to request follow-up review of the
+            introduced changes by the security team. Please refer to {url} for
+            more information."""
+        )
+):
+    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/CheckPAMModules.py
+++ b/CheckPAMModules.py
@@ -44,19 +44,14 @@ check = PAMModulesCheck()
 
 if Config.info:
 
-    for _id, desc in (
+    Whitelisting.registerErrorDetails((
         (
             'suse-pam-unauthorized-module',
-            """The package installs a PAM module. If the package
-            is intended for inclusion in any SUSE product please open a bug
-            report to request review of the service by the security team.
-            Please refer to {url}"""
+            """The package installs a PAM module. {review_needed_text}"""
         ),
         (
             'suse-pam-ghost-module',
-            """The package installs a PAM module as %ghost file. This is not
-            allowed as it is impossible to review. For more information please
-            refer to {url} for more information."""
+            """The package installs a PAM module as %ghost file.
+            {ghost_encountered_text}"""
         )
-    ):
-        addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))
+    ))

--- a/CheckPolkitPrivs.py
+++ b/CheckPolkitPrivs.py
@@ -196,57 +196,56 @@ class PolkitCheck(AbstractCheck.AbstractCheck):
 
 check = PolkitCheck()
 
-for _id, desc in (
-        (
-            'polkit-unauthorized-file',
-            """A custom polkit rule file is installed by this package. If the package is
-            intended for inclusion in any SUSE product please open a bug report to request
-            review of the package by the security team. Please refer to {url} for more
-            information"""
-        ),
-        (
-            'polkit-unauthorized-privilege',
-            """The package allows unprivileged users to carry out privileged
-            operations without authentication. This could cause security
-            problems if not done carefully. If the package is intended for
-            inclusion in any SUSE product please open a bug report to request
-            review of the package by the security team. Please refer to {url}
-            for more information."""
-        ),
-        (
-            'polkit-untracked-privilege',
-            """The privilege is not listed in /etc/polkit-default-privs.*
-            which makes it harder for admins to find. Furthermore polkit
-            authorization checks can easily introduce security issues. If the
-            package is intended for inclusion in any SUSE product please open
-            a bug report to request review of the package by the security team.
-            Please refer to {url} for more information."""
-        ),
-        (
-            'polkit-cant-acquire-privilege',
-            """Usability can be improved by allowing users to acquire privileges
-            via authentication. Use e.g. 'auth_admin' instead of 'no' and make
-            sure to define 'allow_any'. This is an issue only if the privilege
-            is not listed in /etc/polkit-default-privs.*"""
-        ),
-        (
-            'polkit-unauthorized-rules',
-            """A polkit rules file installed by this package is not whitelisted in the
-            polkit-whitelisting package. If the package is intended for inclusion in any
-            SUSE product please open a bug report to request review of the package by the
-            security team. Please refer to {url} for more information."""
-        ),
-        (
-            'polkit-changed-rules',
-            """A polkit rules file installed by this package changed in content. Please
-            open a bug report to request follow-up review of the introduced changes by
-            the security team. Please refer to {url} for more information."""
-        ),
-        (
-            'polkit-ghost-file',
-            """This package installs a polkit rule or policy as %ghost file.
-            This is not allowed as it is impossible to review. For more
-            information please refer to {url} for more information."""
-        )
-):
-    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))
+Whitelisting.registerErrorDetails((
+    (
+        'polkit-unauthorized-file',
+        """A custom polkit rule file is installed by this package. If the package is
+        intended for inclusion in any SUSE product please open a bug report to request
+        review of the package by the security team. Please refer to {url} for more
+        information"""
+    ),
+    (
+        'polkit-unauthorized-privilege',
+        """The package allows unprivileged users to carry out privileged
+        operations without authentication. This could cause security
+        problems if not done carefully. If the package is intended for
+        inclusion in any SUSE product please open a bug report to request
+        review of the package by the security team. Please refer to {url}
+        for more information."""
+    ),
+    (
+        'polkit-untracked-privilege',
+        """The privilege is not listed in /etc/polkit-default-privs.*
+        which makes it harder for admins to find. Furthermore polkit
+        authorization checks can easily introduce security issues. If the
+        package is intended for inclusion in any SUSE product please open
+        a bug report to request review of the package by the security team.
+        Please refer to {url} for more information."""
+    ),
+    (
+        'polkit-cant-acquire-privilege',
+        """Usability can be improved by allowing users to acquire privileges
+        via authentication. Use e.g. 'auth_admin' instead of 'no' and make
+        sure to define 'allow_any'. This is an issue only if the privilege
+        is not listed in /etc/polkit-default-privs.*"""
+    ),
+    (
+        'polkit-unauthorized-rules',
+        """A polkit rules file installed by this package is not whitelisted in the
+        polkit-whitelisting package. If the package is intended for inclusion in any
+        SUSE product please open a bug report to request review of the package by the
+        security team. Please refer to {url} for more information."""
+    ),
+    (
+        'polkit-changed-rules',
+        """A polkit rules file installed by this package changed in content. Please
+        open a bug report to request follow-up review of the introduced changes by
+        the security team. Please refer to {url} for more information."""
+    ),
+    (
+        'polkit-ghost-file',
+        """This package installs a polkit rule or policy as %ghost file.
+        This is not allowed as it is impossible to review. For more
+        information please refer to {url} for more information."""
+    )
+))

--- a/CheckPolkitPrivs.py
+++ b/CheckPolkitPrivs.py
@@ -52,11 +52,11 @@ class PolkitCheck(AbstractCheck.AbstractCheck):
         for filename in POLKIT_RULES_WHITELIST:
             if not os.path.exists(filename):
                 continue
-            parser = Whitelisting.WhitelistParser(filename)
+            parser = Whitelisting.DigestWhitelistParser(filename)
             res = parser.parse()
             rules_entries.update(res)
 
-        self.m_rules_checker = Whitelisting.WhitelistChecker(
+        self.m_rules_checker = Whitelisting.DigestWhitelistChecker(
             rules_entries,
             restricted_paths=(
                 "/etc/polkit-1/rules.d/", "/usr/share/polkit-1/rules.d/"

--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -189,12 +189,6 @@ class SUIDCheck(AbstractCheck.AbstractCheck):
                                 'pie executable' not in pkgfile.magic):
                             printError(pkg, 'non-position-independent-executable', f)
 
-                if mode & stat.S_IWOTH:
-                    need_verifyscript = True
-                    printError(pkg, 'permissions-world-writable',
-                               '%(file)s is packaged with world writable permissions (0%(mode)o)' %
-                               {'file': f, 'mode': mode})
-
             script = pkg[rpm.RPMTAG_POSTIN] or pkg.scriptprog(rpm.RPMTAG_POSTINPROG)
             found = False
             if script:
@@ -284,13 +278,6 @@ for _id, desc in (
         ),
         (
             'permissions-directory-setuid-bit',
-            """If the package is intended for inclusion in any SUSE product
-            please open a bug report to request review of the package by the
-            security team. Please refer to {url} for more
-            information."""
-        ),
-        (
-            'permissions-world-writable',
             """If the package is intended for inclusion in any SUSE product
             please open a bug report to request review of the package by the
             security team. Please refer to {url} for more

--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function
 
-from Filter import printWarning, printError, printInfo, addDetails
+from Filter import printWarning, printError, printInfo
 import AbstractCheck
 import Whitelisting
 import os
@@ -236,83 +236,73 @@ class SUIDCheck(AbstractCheck.AbstractCheck):
 
 check = SUIDCheck()
 
-for _id, desc in (
-        (
-            'permissions-unauthorized-file',
-            """If the package is intended for inclusion in any SUSE product
-            please open a bug report to request review of the package by the
-            security team. Please refer to {url} for more
-            information."""
-        ),
-        (
-            'permissions-symlink',
-            """permissions handling for symlinks is useless. Please contact
-            security@suse.de to remove the entry. Please refer to {url} for more
-            information."""
-        ),
-        (
-            'permissions-dir-without-slash',
-            """the entry in the permissions file refers to a directory. Please
-            contact security@suse.de to append a slash to the entry in order to
-            avoid security problems. Please refer to {url} for more information."""
-        ),
-        (
-            'permissions-file-as-dir',
-            """the entry in the permissions file refers to a directory but the
-            package actually contains a file. Please contact security@suse.de to
-            remove the slash. Please refer to {url} for more information."""
-        ),
-        (
-            'permissions-incorrect',
-            """please use the %attr macro to set the correct permissions."""
-        ),
-        (
-            'permissions-incorrect-owner',
-            """please use the %attr macro to set the correct ownership."""
-        ),
-        (
-            'permissions-file-setuid-bit',
-            """If the package is intended for inclusion in any SUSE product
-            please open a bug report to request review of the program by the
-            security team. Please refer to {url} for more information."""
-        ),
-        (
-            'permissions-directory-setuid-bit',
-            """If the package is intended for inclusion in any SUSE product
-            please open a bug report to request review of the package by the
-            security team. Please refer to {url} for more
-            information."""
-        ),
-        (
-            'permissions-fscaps',
-            """Packaging file capabilities is currently not supported. Please
-            use normal permissions instead. You may contact the security team to
-            request an entry that sets capabilities in
-            /usr/share/permissions/permissions instead.""",
-        ),
-        (
-            'permissions-missing-postin',
-            """Please add an appropriate %post section"""
-        ),
-        (
-            'permissions-missing-requires',
-            """Please add 'PreReq: permissions'"""
-        ),
-        (
-            'permissions-missing-verifyscript',
-            """Please add a %verifyscript section"""
-        ),
-        (
-            'permissions-suseconfig-obsolete',
-            """The %run_permissions macro calls SuSEconfig which sets permissions for all
-            files in the system. Please use %set_permissions <filename> instead
-            to only set permissions for files contained in this package""",
-        ),
-        (
-            'permissions-ghostfile',
-            """This package installs a permissions file as a %ghost file. This
-            is not allowed as it is impossible to review. Please refer to
-            {url} for more information."""
-        )
-):
-    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))
+Whitelisting.registerErrorDetails((
+    (
+        'permissions-unauthorized-file',
+        """{review_needed_text}"""
+    ),
+    (
+        'permissions-symlink',
+        """permissions handling for symlinks is useless. Please contact
+        security@suse.de to remove the entry. Please refer to {url} for more
+        information."""
+    ),
+    (
+        'permissions-dir-without-slash',
+        """the entry in the permissions file refers to a directory. Please
+        contact security@suse.de to append a slash to the entry in order to
+        avoid security problems. Please refer to {url} for more information."""
+    ),
+    (
+        'permissions-file-as-dir',
+        """the entry in the permissions file refers to a directory but the
+        package actually contains a file. Please contact security@suse.de to
+        remove the slash. Please refer to {url} for more information."""
+    ),
+    (
+        'permissions-incorrect',
+        """please use the %attr macro to set the correct permissions."""
+    ),
+    (
+        'permissions-incorrect-owner',
+        """please use the %attr macro to set the correct ownership."""
+    ),
+    (
+        'permissions-file-setuid-bit',
+        """{review_needed_text}"""
+    ),
+    (
+        'permissions-directory-setuid-bit',
+        """{review_needed_text}"""
+    ),
+    (
+        'permissions-fscaps',
+        """Packaging file capabilities is currently not supported. Please
+        use normal permissions instead. You may contact the security team to
+        request an entry that sets capabilities in
+        /usr/share/permissions/permissions instead.""",
+    ),
+    (
+        'permissions-missing-postin',
+        """Please add an appropriate %post section"""
+    ),
+    (
+        'permissions-missing-requires',
+        """Please add 'PreReq: permissions'"""
+    ),
+    (
+        'permissions-missing-verifyscript',
+        """Please add a %verifyscript section"""
+    ),
+    (
+        'permissions-suseconfig-obsolete',
+        """The %run_permissions macro calls SuSEconfig which sets permissions for all
+        files in the system. Please use %set_permissions <filename> instead
+        to only set permissions for files contained in this package""",
+    ),
+    (
+        'permissions-ghostfile',
+        """This package installs a permissions file as a %ghost file.
+        {ghost_encountered_text}"""
+    )
+))

--- a/CheckWorldWritable.py
+++ b/CheckWorldWritable.py
@@ -66,20 +66,15 @@ class WorldWritableCheck(AbstractCheck.AbstractCheck):
 # needs to be instantiated for the check to be registered with rpmlint
 check = WorldWritableCheck()
 
-for _id, desc in (
-        (
-            'world-writable-unauthorized-file',
-            """A world-writable file is installed by this package. If the
-            package is intended for inclusion in any SUSE product please open
-            a bug report to request review of the package by the security
-            team.  Please refer to {url} for more information"""
-        ),
-        (
-            'world-writable-mismatched-attrs',
-            """A world-writable file doesn't match the expected file
-            properties.  Please open a bug report to request follow-up review
-            of the introduced changes by the security team. Please refer to
-            {url} for more information."""
-        )
-):
-    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))
+Whitelisting.registerErrorDetails((
+    (
+        'world-writable-unauthorized-file',
+        """A world-writable file is installed by this package.
+        {review_needed_text}"""
+    ),
+    (
+        'world-writable-mismatched-attrs',
+        """A world-writable file doesn't match the expected file
+        properties. {followup_needed_text}"""
+    )
+))

--- a/CheckWorldWritable.py
+++ b/CheckWorldWritable.py
@@ -1,0 +1,85 @@
+# vim: sw=4 ts=4 sts=4 et :
+#############################################################################
+# Author        : Matthias Gerstner
+# Purpose       : Enforce Whitelisting for world writable files
+#############################################################################
+
+import os
+
+import AbstractCheck
+import Config
+import Whitelisting
+
+from Filter import addDetails
+
+# this option is found in config files in /opt/testing/share/rpmlint/mini,
+# installed there by the rpmlint-mini package.
+WHITELIST_DIR = Config.getOption('WhitelistDataDir', [])
+
+
+class WorldWritableCheck(AbstractCheck.AbstractCheck):
+
+    def __init__(self):
+        AbstractCheck.AbstractCheck.__init__(self, "CheckWorldWritable")
+
+        for wd in WHITELIST_DIR:
+            candidate = os.path.join(wd, "world-writable-whitelist.json")
+            if os.path.exists(candidate):
+                whitelist_path = candidate
+                break
+        else:
+            whitelist_path = None
+
+        self.m_check_configured = whitelist_path is not None
+
+        if not self.m_check_configured:
+            return
+
+        parser = Whitelisting.MetaWhitelistParser(whitelist_path)
+        whitelist_entries = parser.parse()
+        self.m_wl_checker = Whitelisting.MetaWhitelistChecker(
+            whitelist_entries,
+            error_map={
+                "unauthorized": "world-writable-unauthorized-file",
+                "mismatch": "world-writable-mismatched-attrs",
+            },
+            # we're only interested in directories, regular files, pipes or
+            # sockets.
+            # devices are handled by the DeviceFileChecker. Symlinks are
+            # always world-writable.
+            restricted_types=("-", "f", "d", "s", "p"),
+            # we're interested in any world-writable files
+            restricted_mode=0o0002,
+        )
+
+    def check(self, pkg):
+        """This is called by rpmlint to perform the check on the given pkg."""
+
+        if not self.m_check_configured:
+            # don't ruin the whole run if this check is not configured, this
+            # was hopefully intended by the user.
+            return
+
+        self.m_wl_checker.check(pkg)
+
+
+# needs to be instantiated for the check to be registered with rpmlint
+check = WorldWritableCheck()
+
+for _id, desc in (
+        (
+            'world-writable-unauthorized-file',
+            """A world-writable file is installed by this package. If the
+            package is intended for inclusion in any SUSE product please open
+            a bug report to request review of the package by the security
+            team.  Please refer to {url} for more information"""
+        ),
+        (
+            'world-writable-mismatched-attrs',
+            """A world-writable file doesn't match the expected file
+            properties.  Please open a bug report to request follow-up review
+            of the introduced changes by the security team. Please refer to
+            {url} for more information."""
+        )
+):
+    addDetails(_id, desc.format(url=Whitelisting.AUDIT_BUG_URL))

--- a/Whitelisting.py
+++ b/Whitelisting.py
@@ -6,8 +6,9 @@
 
 import os
 import sys
-import json
 import hashlib
+import json
+import stat
 import traceback
 
 AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
@@ -202,6 +203,135 @@ class DigestAuditEntry(AuditEntryBase):
             raise Exception("Bad digest algorithm in " + digest)
 
 
+class MetaAuditEntry(AuditEntryBase):
+
+    def __init__(self, bug):
+
+        super().__init__(bug)
+        self.m_meta = {}
+
+    def paths(self):
+        return self.meta().keys()
+
+    def setMeta(self, meta):
+        for path, data in meta.items():
+            self._verifyPath(path)
+            self._verifyMetaData(path, data)
+
+        self.m_meta = meta
+
+    def meta(self):
+        """Returns a dictionary specifying file paths and their whitelisted
+        metadata attributes:
+
+        "type": one of 'c', 'd', 's' or '-'
+        "mode": integer defining the file mode
+        "owner": tuple of (user, group) defining the ownership
+        "dev": tuple of (minor, major) integers defining device file numbers
+        """
+        return self.m_meta
+
+    def _verifyMetaData(self, path, data):
+        """Verify and CONVERT metadata."""
+
+        req_fields = ("type", "mode", "owner")
+
+        for field in req_fields:
+            if field not in data:
+                raise Exception("Missing required setting '{}' for path {}".format(field, path))
+
+        _type = data["type"]
+
+        if _type not in ("c", "d", "s", "-"):
+            raise Exception("Unexpected type '{}' for path {}".format(_type, path))
+
+        try:
+            data["mode"] = int(data["mode"], 8)
+
+            if data["mode"] > 0o7777:
+                raise ValueError("octal mode too large")
+        except ValueError:
+            raise Exception("Bad 'mode' for path " + path)
+
+        if _type == "c" and "dev" not in data:
+            raise Exception("Missing 'dev' for path " + path)
+        elif _type != "c" and "dev" in data:
+            raise Exception("Unsuitable 'dev' specification for path " + path)
+
+        if "dev" in data:
+            try:
+                major, minor = data["dev"].split(",")
+                data["dev"] = int(major), int(minor)
+            except Exception as e:
+                raise Exception("Bad 'dev' specification for path {}: {}".format(path, str(e)))
+
+        try:
+            user, group = data["owner"].split(":")
+            data["owner"] = user, group
+        except Exception as e:
+            raise Exception("Bad 'owner' specification for path {}: {}".format(path, str(e)))
+
+    def _isWeakerMode(self, ours, theirs):
+        """Checks whether the mode @theirs only grants less permissions than
+        what @ours would grant."""
+
+        if (ours & stat.S_ISVTX) and not (theirs & stat.S_ISVTX):
+            # if it's the sticky bit that's missing then we can't consider the
+            # encountered mode weaker. The sticky bit might be necessary to
+            # protect shared world-writable directories.
+            return False
+
+        # otherwise if there's no extra bit in their mode then it should be
+        # weaker or equal to ours, security wise
+        return (ours | theirs) == ours
+
+    def compareMeta(self, pkg, path, their_meta):
+        our_meta = self.m_meta.get(path)
+        warning = ""
+
+        their_mode_str = stat.filemode(their_meta.mode)
+        their_type = their_mode_str[0]
+
+        if their_type != our_meta["type"]:
+            msg = "type mismatch, expected type {} but encountered type {}".format(
+                our_meta["type"], their_type
+            )
+            return (False, msg)
+
+        their_mode = stat.S_IMODE(their_meta.mode)
+
+        if their_mode != our_meta["mode"]:
+
+            if self._isWeakerMode(our_meta["mode"], their_mode):
+                # if there are no extra bits set then we can accept it
+                # anyways, however we should still warn that something is
+                # unexpected.
+                warning = "mode doesn't match but grants less permissions than expected"
+            else:
+                msg = "mode mismatch, expected mode {} but encountered mode {}".format(
+                    stat.filemode(our_meta["mode"])[1:], stat.filemode(their_meta.mode)[1:]
+                )
+                return (False, msg)
+
+        if their_meta.user != our_meta["owner"][0] or their_meta.group != our_meta["owner"][1]:
+            msg = "ownership mismatch, expected {} but encountered {}".format(
+                ':'.join(our_meta["owner"]), ':'.join(their_meta.user, their_meta.group)
+            )
+            return (False, msg)
+
+        if their_type in ("c", "b"):
+            their_rdev = their_meta.rdev
+            their_major, their_minor = os.major(their_rdev), os.minor(their_rdev)
+            our_major, our_minor = our_meta["dev"]
+
+            if their_major != our_major or their_minor != our_minor:
+                msg = "device node mismatch, expected {} but encountered {}".format(
+                    ','.join(our_major, our_minor), ','.join(their_major, their_minor)
+                )
+                return (False, msg)
+
+        return (True, warning)
+
 
 class WhitelistEntry(object):
     """This object represents a single whitelisting entry like:
@@ -337,6 +467,31 @@ class DigestWhitelistParser(WhitelistParser):
         return ret
 
 
+class MetaWhitelistParser(WhitelistParser):
+
+    def __init__(self, wl_path):
+
+        super().__init__(wl_path)
+
+    def _parseAuditEntry(self, bug, data):
+        """Parses a single JSON audit sub-entry returns an AuditEntry() object
+        for it. On non-critical error conditions None is returned, otherwise
+        an exception is raised"""
+
+        ret = MetaAuditEntry(bug)
+
+        comment = data.get("comment", None)
+        if comment:
+            ret.setComment(comment)
+
+        meta = data.get("meta", {})
+
+        if not meta:
+            raise Exception(self._getErrorPrefix() + "missing 'meta' entry for '{}'".format(bug))
+
+        ret.setMeta(meta)
+
+        return ret
 
 
 class DigestWhitelistChecker(object):
@@ -461,3 +616,110 @@ class DigestWhitelistChecker(object):
                 path=result.path(), alg=result.algorithm(),
                 expected=result.expected(), encountered=result.encountered()
             ), file=sys.stderr)
+
+
+class MetaWhitelistChecker(object):
+    """This type actually compares files found in an RPM against whitelist
+    entries."""
+
+    def __init__(self, whitelist_entries, error_map, restricted_mode, restricted_types):
+        """Instantiate a properly configured checker. For metadata
+        restrictions both `restricted_mode` and `restricted_types` need to
+        match for a check to be triggered.
+
+        :param whitelist_entries: is a dictionary data structure as returned
+                                  from MetaWhitelistParser.parse().
+        :param error_map: is a specification of rpmlint error labels for
+                          files like "unauthorized" and "mismatch"
+                          {
+                            "unauthorized": "special-file-unauthorized",
+                            "mismatch": "special-file-mismatch"
+                          }
+        :param restricted_mode: an octal bit mask that specifies file mode
+                                bits that are restricted by this whitelist.
+                                e.g. 0o001 would trigger a check for all files
+                                containing a world executable bit. 0o7777
+                                would catch any mode.
+        :param restricted_types: a sequence of file types that are restricted
+                                by this whitelist. E.g. ("f", "s") would
+                                trigger a check for all regular files and
+                                socket files. An entry of "*" will match all
+                                file types.
+        """
+
+        self.m_whitelist_entries = whitelist_entries
+        self.m_error_map = error_map
+        self.m_restricted_mode = restricted_mode
+        self.m_restricted_types = restricted_types
+
+        req_error_keys = ("unauthorized", "mismatch")
+
+        for req_key in req_error_keys:
+            if req_key not in self.m_error_map:
+                raise Exception("Missing {} error mapping".format(req_key))
+
+    def _hasRestrictedMeta(self, meta):
+
+        if self.m_restricted_mode == 0o7777:
+            # all modes should match so ignore it
+            pass
+        elif (meta.mode & self.m_restricted_mode) == 0:
+            # none of the interesting mode bits matches
+            return False
+
+        if "*" in self.m_restricted_types:
+            # match all file types
+            return True
+        elif stat.filemode(meta.mode)[0] in self.m_restricted_types:
+            # filemode() returns an ls like string like `-rwx------`.
+            # we # inspect the type character and compare it against our list
+            # of restricted file types
+            return True
+
+        return False
+
+    def _getWhitelist(self, pkg_name, path):
+        entries = self.m_whitelist_entries.get(path, [])
+        for entry in entries:
+            if entry.package() == pkg_name:
+                return entry
+
+        return None
+
+    def check(self, pkg):
+        """Checks the given RPM pkg instance against the configured whitelist
+        restriction.
+
+        Each whitelist violation will be printed with the according error tag.
+        Nothing is returned from this function.
+        """
+
+        from Filter import printError
+
+        if pkg.isSource():
+            return
+
+        files = pkg.files()
+
+        for f, meta in files.items():
+            if not self._hasRestrictedMeta(meta):
+                continue
+
+            wl_match = self._getWhitelist(pkg.name, f)
+
+            if not wl_match:
+                # no whitelist entry exists for this file
+                printError(pkg, self.m_error_map['unauthorized'], f)
+                continue
+
+            for audit in wl_match.audits():
+                res, msg = audit.compareMeta(pkg, f, meta)
+
+                if res:
+                    if msg:
+                        # a warning only message
+                        print("{}: {}".format(f, msg), file=sys.stderr)
+                    break
+
+                print("{}: {}".format(f, msg), file=sys.stderr)
+                printError(pkg, self.m_error_map['mismatch'], f)

--- a/Whitelisting.py
+++ b/Whitelisting.py
@@ -12,6 +12,32 @@ import stat
 import traceback
 
 AUDIT_BUG_URL = "https://en.opensuse.org/openSUSE:Package_security_guidelines#audit_bugs"
+REVIEW_NEEDED_TEXT = """If the package is
+    intended for inclusion in any SUSE product please open a bug report to request
+    review of the package by the security team. Please refer to {url} for more
+    information.""".format(url=AUDIT_BUG_URL)
+FOLLOWUP_NEEDED_TEXT = """Please open a bug report to request follow-up review of the
+    introduced changes by the security team. Please refer to {url} for more
+    information."""
+GHOST_ENCOUNTERED_TEXT = """This is not allowed, since it is impossible to
+    review. Please refer to {url} for more information."""
+
+
+def registerErrorDetails(details):
+    """details is expected to be a sequence of (id, description) pairs, where
+    id is the error id like 'cronjob-unauthorized-file' and description is a
+    human readable text describing the situation. The text may contain
+    placeholders that will be replaced by the constants above."""
+    from Filter import addDetails
+
+    for _id, desc in details:
+        addDetails(
+            _id,
+            desc.format(
+                url=AUDIT_BUG_URL,
+                review_needed_text=REVIEW_NEEDED_TEXT,
+                followup_needed_text=FOLLOWUP_NEEDED_TEXT,
+                ghost_encountered_text=GHOST_ENCOUNTERED_TEXT))
 
 
 class DigestVerificationResult(object):

--- a/WhitelistingCheckBase.py
+++ b/WhitelistingCheckBase.py
@@ -1,0 +1,42 @@
+# vim: sw=4 ts=4 sts=4 et :
+#############################################################################
+# Author        : Matthias Gerstner
+# Purpose       : Common base class for whitelisting related checks
+#############################################################################
+import AbstractCheck
+import Config
+
+import os
+
+
+class WhitelistingCheckBase(AbstractCheck.AbstractCheck):
+    """Base class for rpmlint checks that use the Whitelisting module."""
+
+    def __init__(self, check_name, whitelist_name):
+        AbstractCheck.AbstractCheck.__init__(self, check_name)
+        # this option is found in config files in /opt/testing/share/rpmlint/mini,
+        # installed there by the rpmlint-mini package.
+        WHITELIST_DIR = Config.getOption('WhitelistDataDir', [])
+
+        for wd in WHITELIST_DIR:
+            candidate = os.path.join(wd, whitelist_name)
+            if os.path.exists(candidate):
+                whitelist_path = candidate
+                self.m_check_configured = True
+                break
+        else:
+            self.m_check_configured = False
+
+        if self.m_check_configured:
+            self.m_wl_checker = self.setupChecker(whitelist_path)
+
+    def check(self, pkg):
+        """This is called by rpmlint to perform the cron check on the given
+        pkg."""
+
+        if not self.m_check_configured:
+            # don't ruin the whole run if this check is not configured, this
+            # was hopefully intended by the user.
+            return
+
+        self.m_wl_checker.check(pkg)


### PR DESCRIPTION
This implements new whitelisting restrictions based on file metadata to control device files and world-writable files. This adresses openSUSE/permissions#88.

This PR also contains a bit of refactoring to avoid redundancy.