### PR TITLE
Permissions: be robust against variables.conf not existing

### DIFF
--- a/Permissions.py
+++ b/Permissions.py
@@ -55,8 +55,13 @@ class VariablesHandler:
 
         self.m_variables = {}
 
-        with open(variables_conf_path) as fd:
-            self._parse(variables_conf_path, fd)
+        try:
+            with open(variables_conf_path) as fd:
+                self._parse(variables_conf_path, fd)
+        except FileNotFoundError:
+            # this can happen during migration in OBS when the new permissions
+            # package is not yet around
+            pass
 
     def _parse(self, label, fd):
 


### PR DESCRIPTION
The rpmlint package runs tests and checks that fail as long as the old
permission package is still around.