### PR TITLE
permissions.d whitelist: add 'exim' (bsc#1240755)

### DIFF
--- a/CheckSUIDPermissions.py
+++ b/CheckSUIDPermissions.py
@@ -23,7 +23,8 @@ _permissions_d_whitelist = (
     "sendmail",
     "sendmail.paranoid",
     "texlive",
-    "texlive.texlive"
+    "texlive.texlive",
+    "exim"
 )
 
 


### PR DESCRIPTION
we dropped the generic /var/spool/mail entry from the permissions package, thus we now need more dedicated drop-in files like in this case for Exim.